### PR TITLE
Revamp dashboard interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,34 @@
 import { useState } from 'react'
 import CadastroPalestra from './components/CadastroPalestra'
 import ListaPalestras from './components/ListaPalestras'
+import Header from './components/Header'
 import styles from './App.module.css'
 import { Palestra } from './types/Palestra'
 
 function App() {
   const [palestraSelecionada, setPalestraSelecionada] = useState<Palestra | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
 
   const handleEditarPalestra = (palestra: Palestra) => {
-    if (palestraSelecionada?.id === palestra.id) {
-      setPalestraSelecionada(null)
-    } else {
-      setPalestraSelecionada(palestra)
-    }
+    setPalestraSelecionada(palestra)
+    setModalOpen(true)
+  }
+
+  const handleNovo = () => {
+    setPalestraSelecionada(null)
+    setModalOpen(true)
   }
 
   return (
     <div className={styles.app}>
-      <header className={styles.header}>
-        <h1>Gestão de Palestras</h1>
-      </header>
+      <Header onNovoEvento={handleNovo} />
       <main className={styles.main}>
         <ListaPalestras onEditar={handleEditarPalestra} />
         <CadastroPalestra
           palestraSelecionada={palestraSelecionada}
-          onPalestraSalva={() => setPalestraSelecionada(null)}
+          onPalestraSalva={() => setModalOpen(false)}
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
         />
       </main>
     </div>

--- a/src/components/CadastroPalestra.module.css
+++ b/src/components/CadastroPalestra.module.css
@@ -96,3 +96,50 @@
   color: #dc3545;
   margin-left: 4px;
 }
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+}
+
+.modalContent {
+  background: white;
+  padding: 1rem;
+  border-radius: 8px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tabs button {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+  background: #e5e7eb;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.activeTab {
+  background: #fb923c;
+  color: white;
+}

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -8,11 +8,13 @@ import {v4 as uuidv4} from "uuid";
 
 import { setDoc } from 'firebase/firestore'; // Adicione esta importação
 interface CadastroPalestraProps {
-  palestraSelecionada: Palestra | null;
-  onPalestraSalva: () => void;
+  palestraSelecionada: Palestra | null
+  onPalestraSalva: () => void
+  isOpen: boolean
+  onClose: () => void
 }
 
-export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva }: CadastroPalestraProps) {
+export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva, isOpen, onClose }: CadastroPalestraProps) {
   const [form, setForm] = useState<Palestra>({
     tipo: 'palestra',
     status: '',
@@ -51,6 +53,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva 
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [tab, setTab] = useState<'basico' | 'financeiro' | 'viagem' | 'robo'>('basico')
 
   useEffect(() => {
     if (palestraSelecionada) {
@@ -257,14 +260,27 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva 
       setLoading(false)
     }
   }
+  if (!isOpen) return null
 
   return (
-    <form className={`${styles.form} ${palestraSelecionada ? styles.editing : ''}`} onSubmit={handleSubmit}>
+    <div className={styles.modal}>
+      <div className={styles.modalContent}>
+        <button className={styles.close} onClick={onClose}>×</button>
+        <form className={`${styles.form} ${palestraSelecionada ? styles.editing : ''}`} onSubmit={handleSubmit}>
       <h2>{palestraSelecionada ? 'Editar Palestra' : 'Nova Palestra'}</h2>
-      
+
+      <nav className={styles.tabs}>
+        <button className={tab === 'basico' ? styles.activeTab : ''} onClick={() => setTab('basico')}>Básico</button>
+        <button className={tab === 'financeiro' ? styles.activeTab : ''} onClick={() => setTab('financeiro')}>Financeiro</button>
+        <button className={tab === 'viagem' ? styles.activeTab : ''} onClick={() => setTab('viagem')}>Viagem</button>
+        <button className={tab === 'robo' ? styles.activeTab : ''} onClick={() => setTab('robo')}>Robôs</button>
+      </nav>
+
       {error && <div className={styles.error}>{error}</div>}
       
       {/* Bloco Inicial Prioritário */}
+      {tab === 'basico' && (
+        <>
       <div className={styles.field}>
         <label>Tipo: <span className={styles.required}>*</span></label>
         <select name="tipo" value={form.tipo} onChange={handleChange} required>
@@ -328,7 +344,12 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva 
         <textarea name="observacoes" value={form.observacoes} onChange={handleChange} />
       </div>
 
+      </>
+      )}
+
       {/* Logística */}
+      {tab === 'viagem' && (
+        <>
       <div className={styles.field}>
         <label>Informações de Ida:</label>
         <input type="date" name="infoIda" value={form.infoIda} onChange={handleChange} />
@@ -387,6 +408,12 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva 
         </div>
       )}
 
+      </>
+      )}
+
+      {tab === 'robo' && (
+      <>
+
       <div className={styles.field}>
         <label>Robô:</label>
         <div className={styles.checkboxContainer}>
@@ -403,16 +430,20 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva 
       {form.robo && (
         <div className={styles.field}>
           <label>Observações do Robô:</label>
-          <textarea 
-            name="observacoesRobo" 
-            value={form.observacoesRobo} 
+          <textarea
+            name="observacoesRobo"
+            value={form.observacoesRobo}
             onChange={handleChange}
             placeholder="Digite as observações sobre o robô"
           />
         </div>
       )}
-      
+      </>
+      )}
+
       {/* Venda e Comissão */}
+      {tab === 'financeiro' && (
+        <>
       <div className={styles.field}>
         <label>Vendida Por:</label>
         <input type="text" name="vendidaPor" value={form.vendidaPor} onChange={handleChange} />
@@ -514,23 +545,27 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva 
       </div>
       <div className={styles.field}>
         <label>Custo Final:</label>
-        <input 
-          type="number" 
-          name="custoFinal" 
-          value={form.custoFinal || ''} 
-          onChange={handleChange} 
+        <input
+          type="number"
+          name="custoFinal"
+          value={form.custoFinal || ''}
+          onChange={handleChange}
           placeholder="Digite o valor"
         />
       </div>
 
+      </>
+      )}
 
-      <button 
-        type="submit" 
+      <button
+        type="submit"
         className={styles.button}
         disabled={loading}
       >
         {loading ? 'Salvando...' : 'Salvar Palestra'}
       </button>
-    </form>
+        </form>
+      </div>
+    </div>
   )
 }

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -1,0 +1,96 @@
+.card {
+  position: relative;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.header h3 {
+  flex: 1 0 100%;
+  margin: 0;
+  color: #000;
+}
+
+.badge {
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: white;
+}
+
+.palestra { background: #3b82f6; }
+.curso { background: #6366f1; }
+.outro { background: #8b5cf6; }
+.agendado { background: #06b6d4; }
+.proximo { background: #22c55e; }
+.passado { background: #6b7280; }
+
+.info {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.financeiro {
+  background: #f3f4f6;
+  padding: 0.5rem;
+  border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.lucro {
+  color: #22c55e;
+}
+
+.actions {
+  display: none;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+
+.card:hover .actions {
+  display: flex;
+}
+
+.actions button {
+  flex: 1;
+  padding: 0.25rem;
+  font-size: 0.75rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.details {
+  background: #60a5fa;
+  color: white;
+}
+.edit {
+  background: #fb923c;
+  color: white;
+}
+.delete {
+  background: #ef4444;
+  color: white;
+}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,50 @@
+import { Palestra } from '../types/Palestra'
+import styles from './EventCard.module.css'
+
+interface EventCardProps {
+  event: Palestra
+  onEditar: (p: Palestra) => void
+  onExcluir: (p: Palestra) => void
+  onDetalhes: (p: Palestra) => void
+}
+
+function badgeColor(tipo: string) {
+  switch (tipo) {
+    case 'curso':
+      return styles.curso
+    case 'outro':
+      return styles.outro
+    default:
+      return styles.palestra
+  }
+}
+
+export default function EventCard({ event, onEditar, onExcluir, onDetalhes }: EventCardProps) {
+  const data = new Date(event.dataMarcada + 'T12:00:00')
+  const future = data >= new Date()
+  return (
+    <div className={styles.card}>
+      <div className={styles.header}>
+        <h3>{event.nome}</h3>
+        <span className={`${styles.badge} ${badgeColor(event.tipo)}`}>{event.tipo}</span>
+        {event.agendado && <span className={`${styles.badge} ${styles.agendado}`}>Agendado</span>}
+        <span className={`${styles.badge} ${future ? styles.proximo : styles.passado}`}>{future ? 'Próximo' : 'Passado'}</span>
+      </div>
+      <ul className={styles.info}>
+        <li>📅 {event.dataMarcada}</li>
+        <li>⏰ {event.horarioEvento}</li>
+        <li>📍 {event.local}</li>
+        <li>👤 {event.vendidaPor}</li>
+      </ul>
+      <div className={styles.financeiro}>
+        <div>R$ {event.valorVenda}</div>
+        <div className={styles.lucro}>Lucro: R$ {event.lucroFinal}</div>
+      </div>
+      <div className={styles.actions}>
+        <button className={styles.details} onClick={() => onDetalhes(event)}>👁️ Ver Detalhes</button>
+        <button className={styles.edit} onClick={() => onEditar(event)}>✏️ Editar</button>
+        <button className={styles.delete} onClick={() => onExcluir(event)}>🗑️ Excluir</button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/FilterButtons.module.css
+++ b/src/components/FilterButtons.module.css
@@ -1,0 +1,32 @@
+.filters {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.button {
+  padding: 0.5rem 1rem;
+  background: #e5e7eb;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.button:hover {
+  background: #d1d5db;
+}
+
+.activeTodos {
+  background: #fb923c;
+  color: white;
+}
+
+.activeProximos {
+  background: #22c55e;
+  color: white;
+}
+
+.activePassados {
+  background: #6b7280;
+  color: white;
+}

--- a/src/components/FilterButtons.tsx
+++ b/src/components/FilterButtons.tsx
@@ -1,0 +1,33 @@
+import styles from './FilterButtons.module.css'
+
+export type Filter = 'todos' | 'proximos' | 'passados'
+
+interface FilterButtonsProps {
+  active: Filter
+  onChange: (f: Filter) => void
+}
+
+export default function FilterButtons({ active, onChange }: FilterButtonsProps) {
+  return (
+    <div className={styles.filters}>
+      <button
+        className={`${styles.button} ${active === 'todos' ? styles.activeTodos : ''}`}
+        onClick={() => onChange('todos')}
+      >
+        Todos
+      </button>
+      <button
+        className={`${styles.button} ${active === 'proximos' ? styles.activeProximos : ''}`}
+        onClick={() => onChange('proximos')}
+      >
+        Próximos
+      </button>
+      <button
+        className={`${styles.button} ${active === 'passados' ? styles.activePassados : ''}`}
+        onClick={() => onChange('passados')}
+      >
+        Passados
+      </button>
+    </div>
+  )
+}

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -1,0 +1,36 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.header h1 {
+  margin: 0;
+  color: #000;
+  font-size: 1.5rem;
+}
+
+.newButton {
+  background: #06b6d4; /* cyan */
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.newButton:hover {
+  background: #0891b2;
+}
+
+.plus {
+  font-size: 1.2rem;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,16 @@
+import styles from './Header.module.css'
+
+interface HeaderProps {
+  onNovoEvento: () => void
+}
+
+export default function Header({ onNovoEvento }: HeaderProps) {
+  return (
+    <header className={styles.header}>
+      <h1>DashTony</h1>
+      <button className={styles.newButton} onClick={onNovoEvento}>
+        <span className={styles.plus}>+</span> Novo Evento
+      </button>
+    </header>
+  )
+}

--- a/src/components/ListaPalestras.module.css
+++ b/src/components/ListaPalestras.module.css
@@ -1,213 +1,51 @@
 .container {
-  padding: 20px;
   width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
+}
+
+.topBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+  margin: 1rem 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
 }
 
 .loading {
   text-align: center;
-  padding: 20px;
-  color: #666;
+  padding: 1rem;
 }
 
-.tableContainer {
-  margin-top: 20px;
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  width: 100%;
-  max-width: 100vw;
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  min-width: 500px;
-  table-layout: auto;
-}
-
-.table th,
-.table td {
-  padding: 12px 0 12px 12px;
-  text-align: left;
-  border-bottom: 1px solid #eee;
-}
-
-.table th {
-  background-color: #f8f9fa;
-  font-weight: 600;
-  color: #333;
-}
-
-.table tr {
-  transition: background-color 0.2s;
-}
-
-.table tr[data-status="Concluída"] {
-  background-color: rgba(40, 167, 69, 0.3); /* green */
-}
-
-.table tr[data-status="Agendada"] {
-  background-color: rgba(255, 193, 7, 0.3); /* yellow */
-}
-
-.table tr[data-status="Cancelada"] {
-  background-color: rgba(220, 53, 69, 0.2); /* red */
-}
-
-.table tr[data-status="Concluída"]:hover {
-  background-color: rgba(40, 167, 69, 0.2);
-}
-
-.table tr[data-status="Agendada"]:hover {
-  background-color: rgba(255, 193, 7, 0.2);
-}
-
-.table tr[data-status="Cancelada"]:hover {
-  background-color: rgba(220, 53, 69, 0.15);
-}
-
-.table td {
-  color: #666;
-}
-
-.table td:first-child {
-  font-weight: 500;
-  color: #333;
-}
-
-.editButton,
-.deleteButton {
-  min-width: 80px;
-  box-sizing: border-box;
-  width: 100%;
-  padding: 2px 4px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 12px;
-  margin-right: 8px;
-  transition: all 0.2s;
-}
-
-.editButton {
-  background-color: #007bff;
-  color: white;
-  padding: 8px 12px;
-}
-
-.editButton:hover {
-  background-color: #0056b3;
-}
-
-.deleteButton {
-  background-color: #dc3545;
-  color: white;
-  font-size: 10px;
-  padding: 4px 12px;
-}
-
-.deleteButton:hover {
-  background-color: #c82333;
-}
-
-.acoes {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  align-items: center;
-  justify-content: center;
-}
-
-/* Modal styles */
 .modal {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  inset: 0;
+  background: rgba(0,0,0,0.5);
   display: flex;
-  justify-content: center;
   align-items: center;
-  z-index: 1000;
+  justify-content: center;
 }
 
 .modalContent {
   background: white;
-  padding: 24px;
-  border-radius: 8px;
+  padding: 1rem;
+  border-radius: 4px;
   width: 90%;
-  max-width: 500px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-}
-
-.modalContent h3 {
-  margin: 0 0 16px 0;
-  color: #dc3545;
-}
-
-.palestraInfo {
-  background: #f8f9fa;
-  padding: 12px;
-  border-radius: 4px;
-  margin: 12px 0;
-}
-
-.confirmacaoTexto {
-  background: #fff3cd;
-  color: #856404;
-  padding: 12px;
-  border-radius: 4px;
-  margin: 12px 0;
-  font-family: monospace;
-}
-
-.confirmacaoInput {
-  width: 100%;
-  padding: 8px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  margin: 12px 0;
-}
-
-.erro {
-  color: #dc3545;
-  margin: 8px 0;
+  max-width: 400px;
 }
 
 .modalBotoes {
   display: flex;
   justify-content: flex-end;
-  gap: 12px;
-  margin-top: 20px;
+  gap: 0.5rem;
+  margin-top: 1rem;
 }
 
-.cancelarButton,
-.confirmarButton {
-  padding: 8px 16px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: 500;
-  transition: all 0.2s;
-}
-
-.cancelarButton {
-  background-color: #6c757d;
-  color: white;
-}
-
-.cancelarButton:hover {
-  background-color: #5a6268;
-}
-
-.confirmarButton {
-  background-color: #dc3545;
-  color: white;
-}
-
-.confirmarButton:hover {
-  background-color: #c82333;
+.erro {
+  color: #ef4444;
 }

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -2,23 +2,21 @@ import { useState, useEffect } from 'react'
 import { db } from '../firebase'
 import { collection, query, onSnapshot, orderBy, deleteDoc, doc } from 'firebase/firestore'
 import { Palestra } from '../types/Palestra'
+import EventCard from './EventCard'
+import SearchBar from './SearchBar'
+import FilterButtons, { Filter } from './FilterButtons'
+import StatsCards from './StatsCards'
 import styles from './ListaPalestras.module.css'
 
 interface ListaPalestrasProps {
-  onEditar: (palestra: Palestra) => void;
-}
-
-const formatarData = (dataString: string) => {
-  const data = new Date(dataString + 'T12:00:00')
-  const dia = data.getDate().toString().padStart(2, '0')
-  const mes = (data.getMonth() + 1).toString().padStart(2, '0')
-  const ano = data.getFullYear().toString().slice(-2)
-  return `${dia}/${mes}/${ano}`
+  onEditar: (p: Palestra) => void
 }
 
 export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
   const [palestras, setPalestras] = useState<Palestra[]>([])
   const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<Filter>('todos')
   const [palestraParaExcluir, setPalestraParaExcluir] = useState<Palestra | null>(null)
   const [confirmacaoTexto, setConfirmacaoTexto] = useState('')
   const [erroConfirmacao, setErroConfirmacao] = useState('')
@@ -26,137 +24,81 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
   useEffect(() => {
     const q = query(collection(db, 'palestras'), orderBy('dataMarcada', 'asc'))
     const unsubscribe = onSnapshot(q, (snapshot) => {
-      const palestrasData = snapshot.docs.map(doc => ({
-        id: doc.id,
-        ...doc.data()
-      })) as Palestra[]
-      setPalestras(palestrasData)
+      const data = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })) as Palestra[]
+      setPalestras(data)
       setLoading(false)
     })
-
     return () => unsubscribe()
   }, [])
 
-  const handleExcluirClick = (palestra: Palestra) => {
-    setPalestraParaExcluir(palestra)
+  const handleExcluirClick = (p: Palestra) => {
+    setPalestraParaExcluir(p)
     setConfirmacaoTexto('')
     setErroConfirmacao('')
   }
 
   const handleConfirmarExclusao = async () => {
     if (!palestraParaExcluir || !palestraParaExcluir.id) return
-
-    const textoEsperado = `EXCLUIR ${palestraParaExcluir.nome.toUpperCase()}`
-    if (confirmacaoTexto !== textoEsperado) {
-      setErroConfirmacao(`Por favor, digite exatamente: ${textoEsperado}`)
+    const esperado = `EXCLUIR ${palestraParaExcluir.nome.toUpperCase()}`
+    if (confirmacaoTexto !== esperado) {
+      setErroConfirmacao(`Por favor, digite exatamente: ${esperado}`)
       return
     }
-
     try {
       await deleteDoc(doc(db, 'palestras', palestraParaExcluir.id))
       setPalestraParaExcluir(null)
-      setConfirmacaoTexto('')
-      setErroConfirmacao('')
-    } catch (error) {
-      console.error('Erro ao excluir palestra:', error)
+    } catch (e) {
       setErroConfirmacao('Erro ao excluir palestra. Tente novamente.')
     }
   }
 
-  if (loading) return <div className={styles.loading}>Carregando...</div>
+  const now = new Date()
+  const futuros = palestras.filter(p => new Date(p.dataMarcada + 'T00:00:00') >= now).length
+  const passados = palestras.length - futuros
+
+  const filtradas = palestras.filter(p => {
+    const termo = search.toLowerCase()
+    const matches = p.nome.toLowerCase().includes(termo)
+    const data = new Date(p.dataMarcada + 'T00:00:00')
+    const isFuture = data >= now
+    if (filter === 'proximos') return matches && isFuture
+    if (filter === 'passados') return matches && !isFuture
+    return matches
+  })
 
   return (
     <div className={styles.container}>
-      <h2>Palestras Cadastradas</h2>
-      <div className={styles.tableContainer}>
-        <table className={styles.table}>
-          <thead>
-            <tr>
-              <th>Data</th>
-              <th>Nome</th>
-              <th>Local</th>
-              <th>Horário</th>
-              <th>🏨</th>
-              <th>✈️</th>
-              <th>🤖</th>
-              <th>Valor</th>
-              <th>Pago</th>
-              <th>Nota</th>
-              <th>Ações</th>
-            </tr>
-          </thead>
-          <tbody>
-            {palestras.map((palestra) => (
-              <tr key={palestra.id} data-status={palestra.status}>
-                <td>{formatarData(palestra.dataMarcada)}</td>
-                <td>{palestra.nome}</td>
-                <td>{palestra.local}</td>
-                <td>{palestra.horarioEvento}</td>
-                <td>{palestra.hospedagemInclusa ? '✅' : ''}</td>
-                <td>{palestra.passagem ? '✅' : ''}</td>
-                <td>{palestra.robo ? '✅' : ''}</td>
-                <td>{palestra.valorVenda}</td>
-                <td>{palestra.pagamentoContratante}</td>
-                <td>{palestra.nota}</td>
-                <td className={styles.acoes}>
-                  <button
-                    className={styles.editButton}
-                    onClick={() => onEditar(palestra)}
-                  >
-                    Detalhes
-                  </button>
-                  <button
-                    className={styles.deleteButton}
-                    onClick={() => handleExcluirClick(palestra)}
-                  >
-                    x
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className={styles.topBar}>
+        <SearchBar value={search} onChange={setSearch} />
+        <FilterButtons active={filter} onChange={setFilter} />
       </div>
+      <StatsCards total={palestras.length} futuros={futuros} passados={passados} />
+      {loading ? (
+        <div className={styles.loading}>Carregando...</div>
+      ) : (
+        <div className={styles.grid}>
+          {filtradas.map(p => (
+            <EventCard
+              key={p.id}
+              event={p}
+              onEditar={onEditar}
+              onExcluir={handleExcluirClick}
+              onDetalhes={onEditar}
+            />
+          ))}
+        </div>
+      )}
 
       {palestraParaExcluir && (
         <div className={styles.modal}>
           <div className={styles.modalContent}>
             <h3>Confirmar Exclusão</h3>
-            <p>Você está prestes a excluir a palestra:</p>
-            <p className={styles.palestraInfo}>
-              <strong>{palestraParaExcluir.nome}</strong> - {formatarData(palestraParaExcluir.dataMarcada)}
-            </p>
-            <p>Para confirmar a exclusão, digite exatamente:</p>
-            <p className={styles.confirmacaoTexto}>
-              EXCLUIR {palestraParaExcluir.nome.toUpperCase()}
-            </p>
-            <input
-              type="text"
-              value={confirmacaoTexto}
-              onChange={(e) => setConfirmacaoTexto(e.target.value)}
-              placeholder="Digite o texto de confirmação"
-              className={styles.confirmacaoInput}
-            />
-            {erroConfirmacao && (
-              <p className={styles.erro}>{erroConfirmacao}</p>
-            )}
+            <p>Digite EXCLUIR {palestraParaExcluir.nome.toUpperCase()} para confirmar.</p>
+            <input value={confirmacaoTexto} onChange={e => setConfirmacaoTexto(e.target.value)} />
+            {erroConfirmacao && <p className={styles.erro}>{erroConfirmacao}</p>}
             <div className={styles.modalBotoes}>
-              <button
-                className={styles.cancelarButton}
-                onClick={() => {
-                  setPalestraParaExcluir(null)
-                  setConfirmacaoTexto('')
-                  setErroConfirmacao('')
-                }}
-              >
-                Cancelar
-              </button>
-              <button
-                className={styles.confirmarButton}
-                onClick={handleConfirmarExclusao}
-              >
-                Confirmar Exclusão
-              </button>
+              <button onClick={() => setPalestraParaExcluir(null)}>Cancelar</button>
+              <button onClick={handleConfirmarExclusao}>Confirmar</button>
             </div>
           </div>
         </div>

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -1,0 +1,21 @@
+.searchBar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #f3f4f6;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  width: 100%;
+  max-width: 400px;
+}
+
+.searchBar input {
+  border: none;
+  background: transparent;
+  flex: 1;
+  outline: none;
+}
+
+.icon {
+  color: #666;
+}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,20 @@
+import styles from './SearchBar.module.css'
+
+interface SearchBarProps {
+  value: string
+  onChange: (v: string) => void
+}
+
+export default function SearchBar({ value, onChange }: SearchBarProps) {
+  return (
+    <div className={styles.searchBar}>
+      <span className={styles.icon}>🔍</span>
+      <input
+        type="text"
+        placeholder="Buscar eventos..."
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  )
+}

--- a/src/components/StatsCards.module.css
+++ b/src/components/StatsCards.module.css
@@ -1,0 +1,26 @@
+.cards {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.card {
+  flex: 1;
+  padding: 1rem;
+  background: white;
+  border-radius: 4px;
+  border-left: 6px solid transparent;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.total {
+  border-color: #fb923c;
+}
+
+.futuro {
+  border-color: #22c55e;
+}
+
+.passado {
+  border-color: #6b7280;
+}

--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -1,0 +1,17 @@
+import styles from './StatsCards.module.css'
+
+interface Stats {
+  total: number
+  futuros: number
+  passados: number
+}
+
+export default function StatsCards({ total, futuros, passados }: Stats) {
+  return (
+    <div className={styles.cards}>
+      <div className={`${styles.card} ${styles.total}`}>Total: {total}</div>
+      <div className={`${styles.card} ${styles.futuro}`}>Futuros: {futuros}</div>
+      <div className={`${styles.card} ${styles.passado}`}>Passados: {passados}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add header with new event button
- implement search, filters and stats cards
- display events as hoverable cards
- reorganize cadastro form into modal with tabs
- update index language

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68474b9a1d84832fa23745fe0c1c4115