### PR TITLE
Add month filter with clear option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,3 @@ export default tseslint.config({
   },
 })
 ```
-<<<<<<<<< Temporary merge branch 1
-npm.cmd run dev
-node dist/server/index.js
-=========
->>>>>>>>> Temporary merge branch 2

--- a/src/components/ListaPalestras.module.css
+++ b/src/components/ListaPalestras.module.css
@@ -49,3 +49,35 @@
 .erro {
   color: #ef4444;
 }
+
+.monthSelector {
+  display: flex;
+  gap: 0.5rem;
+  background: white;
+  padding: 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.clearFilter {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.monthSection {
+  margin-bottom: 2rem;
+}
+
+.monthTitle {
+  text-transform: capitalize;
+  margin: 0 0 0.5rem 0;
+}
+
+.emptyMonth {
+  opacity: 0.5;
+  font-size: 0.875rem;
+  margin-left: 1rem;
+}

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -66,27 +66,103 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
     return matches
   })
 
+  const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth())
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear())
+  const [filterActive, setFilterActive] = useState(false)
+
+  const handleMonthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedMonth(Number(e.target.value))
+    setFilterActive(true)
+  }
+
+  const handleYearChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedYear(Number(e.target.value))
+    setFilterActive(true)
+  }
+
+  const clearFilter = () => setFilterActive(false)
+
+  function formatMonthYear(month: number, year: number) {
+    return new Date(year, month, 1).toLocaleDateString('pt-BR', {
+      month: 'long',
+      year: 'numeric'
+    })
+  }
+
+  const months: { month: number; year: number; eventos: Palestra[] }[] = []
+  if (filtradas.length > 0) {
+    const first = new Date(filtradas[0].dataMarcada + 'T00:00:00')
+    const last = new Date(filtradas[filtradas.length - 1].dataMarcada + 'T00:00:00')
+    let current = new Date(first.getFullYear(), first.getMonth(), 1)
+    const end = new Date(last.getFullYear(), last.getMonth() + 1, 1)
+    while (current <= end) {
+      const y = current.getFullYear()
+      const m = current.getMonth()
+      const eventos = filtradas.filter(e => {
+        const d = new Date(e.dataMarcada + 'T00:00:00')
+        return d.getFullYear() === y && d.getMonth() === m
+      })
+      months.push({ month: m, year: y, eventos })
+      current = new Date(y, m + 1, 1)
+    }
+  } else {
+    const now = new Date()
+    months.push({ month: now.getMonth(), year: now.getFullYear(), eventos: [] })
+    const next = new Date(now.getFullYear(), now.getMonth() + 1, 1)
+    months.push({ month: next.getMonth(), year: next.getFullYear(), eventos: [] })
+  }
+
+  const availableYears = Array.from(new Set(months.map(m => m.year))).sort((a, b) => a - b)
+
+  const displayMonths = filterActive
+    ? months.filter(m => m.month === selectedMonth && m.year === selectedYear)
+    : months
+
   return (
     <div className={styles.container}>
       <div className={styles.topBar}>
         <SearchBar value={search} onChange={setSearch} />
         <FilterButtons active={filter} onChange={setFilter} />
+        <div className={styles.monthSelector}>
+          <select value={selectedMonth} onChange={handleMonthChange}>
+            {Array.from({ length: 12 }).map((_, i) => (
+              <option key={i} value={i}>{new Date(2000, i, 1).toLocaleDateString('pt-BR', { month: 'long' })}</option>
+            ))}
+          </select>
+          <select value={selectedYear} onChange={handleYearChange}>
+            {availableYears.map(y => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+          {filterActive && (
+            <button className={styles.clearFilter} onClick={clearFilter} aria-label="Limpar filtro">×</button>
+          )}
+        </div>
       </div>
       <StatsCards total={palestras.length} futuros={futuros} passados={passados} />
       {loading ? (
         <div className={styles.loading}>Carregando...</div>
       ) : (
-        <div className={styles.grid}>
-          {filtradas.map(p => (
-            <EventCard
-              key={p.id}
-              event={p}
-              onEditar={onEditar}
-              onExcluir={handleExcluirClick}
-              onDetalhes={onEditar}
-            />
-          ))}
-        </div>
+        displayMonths.map(({ month, year, eventos }) => (
+          <div key={`${year}-${month}`} className={styles.monthSection}>
+            <h2 className={styles.monthTitle}>{formatMonthYear(month, year)}</h2>
+            {eventos.length === 0 ? (
+              <p className={styles.emptyMonth}>nada marcado</p>
+            ) : (
+              <div className={styles.grid}>
+                {eventos.map(p => (
+                  <EventCard
+                    key={p.id}
+                    event={p}
+                    onEditar={onEditar}
+                    onExcluir={handleExcluirClick}
+                    onDetalhes={onEditar}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        ))
       )}
 
       {palestraParaExcluir && (


### PR DESCRIPTION
## Summary
- enable filtering by selected month and year
- add clear filter button
- remove scroll-to-month logic

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_685c3fff2118832f8754cebebe71599c