### PR TITLE
Improve dashboard UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dash Tony</title>
   </head>

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,6 +1,6 @@
 .app {
   min-height: 100vh;
-  background-color: #f5f5f5;
+  background-color: #f9fafb;
 }
 
 .app,

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -1,17 +1,17 @@
 .card {
   position: relative;
   background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  padding: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  padding: 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .card:hover {
-  transform: translateY(-2px);
+  transform: translateY(-2px) scale(1.02);
   box-shadow: 0 4px 8px rgba(0,0,0,0.15);
 }
 
@@ -26,11 +26,12 @@
   flex: 1 0 100%;
   margin: 0;
   color: #000;
+  font-size: 1.1rem;
 }
 
 .badge {
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: 8px;
   font-size: 0.75rem;
   color: white;
 }
@@ -47,14 +48,22 @@
   padding: 0;
   margin: 0;
   display: grid;
-  gap: 0.25rem;
+  gap: 0.5rem;
   font-size: 0.875rem;
+}
+.info li {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.icon {
+  color: #6b7280;
 }
 
 .financeiro {
   background: #f3f4f6;
-  padding: 0.5rem;
-  border-radius: 4px;
+  padding: 0.75rem;
+  border-radius: 8px;
   display: flex;
   justify-content: space-between;
 }
@@ -65,7 +74,7 @@
 
 .actions {
   display: none;
-  gap: 0.25rem;
+  gap: 0.5rem;
   margin-top: 0.5rem;
 }
 
@@ -78,7 +87,7 @@
   padding: 0.25rem;
   font-size: 0.75rem;
   border: none;
-  border-radius: 4px;
+  border-radius: 8px;
   cursor: pointer;
 }
 

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -31,10 +31,9 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes }: Ev
         <span className={`${styles.badge} ${future ? styles.proximo : styles.passado}`}>{future ? 'Próximo' : 'Passado'}</span>
       </div>
       <ul className={styles.info}>
-        <li>📅 {event.dataMarcada}</li>
-        <li>⏰ {event.horarioEvento}</li>
-        <li>📍 {event.local}</li>
-        <li>👤 {event.vendidaPor}</li>
+        <li><span className={styles.icon}>📅</span>{event.dataMarcada} {event.horarioEvento}</li>
+        <li><span className={styles.icon}>📍</span>{event.local}</li>
+        <li><span className={styles.icon}>🏷️</span>{event.tipo}</li>
       </ul>
       <div className={styles.financeiro}>
         <div>R$ {event.valorVenda}</div>

--- a/src/components/FilterButtons.module.css
+++ b/src/components/FilterButtons.module.css
@@ -1,32 +1,36 @@
 .filters {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .button {
   padding: 0.5rem 1rem;
   background: #e5e7eb;
   border: none;
-  border-radius: 4px;
+  border-radius: 12px;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .button:hover {
   background: #d1d5db;
+  transform: scale(1.05);
 }
 
 .activeTodos {
   background: #fb923c;
   color: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .activeProximos {
   background: #22c55e;
   color: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .activePassados {
-  background: #6b7280;
+  background: #3b82f6;
   color: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -14,21 +14,23 @@
 }
 
 .newButton {
-  background: #06b6d4; /* cyan */
+  background: #06b6d4;
   color: white;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  padding: 0.5rem 1.25rem;
+  border-radius: 12px;
   cursor: pointer;
   font-weight: 500;
   display: flex;
   align-items: center;
   gap: 4px;
-  transition: background-color 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .newButton:hover {
   background: #0891b2;
+  transform: scale(1.05);
 }
 
 .plus {

--- a/src/components/ListaPalestras.module.css
+++ b/src/components/ListaPalestras.module.css
@@ -5,7 +5,7 @@
 .topBar {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 1.5rem;
   justify-content: space-between;
   align-items: center;
   margin: 1rem 0;
@@ -51,27 +51,32 @@
 }
 
 .monthSelector {
-  background: #f4f0f1;
+  background: #f3f4f6;
   padding: 0.5rem;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
   display: flex;
   gap: 0.5rem;
   z-index: 100;
-
+}
+.monthInput {
+  padding: 0.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
 }
 
 .clearFilter {
   padding: 0.5rem 1rem;
-  background: #740606;
-  border: none;
-  border-radius: 4px;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .clearFilter:hover {
-  background: #ff0000;
+  background: #e5e7eb;
+  transform: scale(1.05);
 }
 
 .monthSection {
@@ -81,10 +86,21 @@
 .monthTitle {
   text-transform: capitalize;
   margin: 0 0 0.5rem 0;
+  color: #6b7280;
+  font-weight: 500;
 }
 
 .emptyMonth {
   opacity: 0.5;
   font-size: 0.875rem;
   margin-left: 1rem;
+}
+
+.fade {
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -20,9 +20,8 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
   const [palestraParaExcluir, setPalestraParaExcluir] = useState<Palestra | null>(null)
   const [confirmacaoTexto, setConfirmacaoTexto] = useState('')
   const [erroConfirmacao, setErroConfirmacao] = useState('')
-  const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth())
-  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear())
-  const [filterByMonth, setFilterByMonth] = useState(false)
+  const [monthFilter, setMonthFilter] = useState('')
+  const [filterLoading, setFilterLoading] = useState(false)
 
   useEffect(() => {
     const q = query(collection(db, 'palestras'), orderBy('dataMarcada', 'asc'))
@@ -33,6 +32,14 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
     })
     return () => unsubscribe()
   }, [])
+
+  useEffect(() => {
+    if (!loading) {
+      setFilterLoading(true)
+      const t = setTimeout(() => setFilterLoading(false), 300)
+      return () => clearTimeout(t)
+    }
+  }, [search, filter, monthFilter])
 
   const handleExcluirClick = (p: Palestra) => {
     setPalestraParaExcluir(p)
@@ -69,10 +76,11 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
     return matches
   })
 
-  if (filterByMonth) {
+  if (monthFilter) {
+    const [year, month] = monthFilter.split('-').map(Number)
     filtradas = filtradas.filter(p => {
       const d = new Date(p.dataMarcada + 'T00:00:00')
-      return d.getMonth() === selectedMonth && d.getFullYear() === selectedYear
+      return d.getMonth() + 1 === month && d.getFullYear() === year
     })
   }
 
@@ -107,12 +115,6 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
     months.push({ month: next.getMonth(), year: next.getFullYear(), eventos: [] })
   }
 
-  const availableYears = Array.from(new Set(
-    palestras.map(p => new Date(p.dataMarcada + 'T00:00:00').getFullYear())
-  )).sort((a, b) => a - b)
-  if (availableYears.length === 0) {
-    availableYears.push(new Date().getFullYear())
-  }
 
   return (
     <div className={styles.container}>
@@ -120,42 +122,30 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
         <SearchBar value={search} onChange={setSearch} />
         <FilterButtons active={filter} onChange={setFilter} />
         <div className={styles.monthSelector}>
-          <select
-            value={selectedMonth}
-            onChange={e => {
-              setSelectedMonth(Number(e.target.value))
-              setFilterByMonth(true)
-            }}
-          >
-            {Array.from({ length: 12 }).map((_, i) => (
-              <option key={i} value={i}>{new Date(2000, i, 1).toLocaleDateString('pt-BR', { month: 'long' })}</option>
-            ))}
-          </select>
-          <select
-            value={selectedYear}
-            onChange={e => {
-              setSelectedYear(Number(e.target.value))
-              setFilterByMonth(true)
-            }}
-          >
-            {availableYears.map(y => (
-              <option key={y} value={y}>{y}</option>
-            ))}
-          </select>
-          <button className={styles.clearFilter} onClick={() => setFilterByMonth(false)}>
-            Limpar Filtro
-          </button>
+          <input
+            type="month"
+            className={styles.monthInput}
+            value={monthFilter}
+            onChange={e => setMonthFilter(e.target.value)}
+            placeholder="Filtrar por mês e ano..."
+          />
+          {monthFilter && (
+            <button className={styles.clearFilter} onClick={() => setMonthFilter('')}>
+              Limpar Filtro
+            </button>
+          )}
         </div>
       </div>
       <StatsCards total={palestras.length} futuros={futuros} passados={passados} />
       {loading ? (
         <div className={styles.loading}>Carregando...</div>
       ) : (
-        months.map(({ month, year, eventos }) => (
-          <div
-            key={`${year}-${month}`}
-            className={styles.monthSection}
-          >
+        <div className={filterLoading ? styles.fade : ''}>
+          {months.map(({ month, year, eventos }) => (
+            <div
+              key={`${year}-${month}`}
+              className={styles.monthSection}
+            >
             <h2 className={styles.monthTitle}>{formatMonthYear(month, year)}</h2>
             {eventos.length === 0 ? (
               <p className={styles.emptyMonth}>nada marcado</p>
@@ -172,8 +162,9 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
                 ))}
               </div>
             )}
-          </div>
-        ))
+            </div>
+          ))}
+        </div>
       )}
 
       {palestraParaExcluir && (

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -3,11 +3,11 @@
   align-items: center;
   gap: 0.5rem;
   background: #f3f4f6;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
   width: 100%;
   max-width: 400px;
-  border: 0.5px solid #1313131a;
+  border: 1px solid #e5e7eb;
 }
 
 .searchBar input {

--- a/src/components/StatsCards.module.css
+++ b/src/components/StatsCards.module.css
@@ -8,9 +8,9 @@
   flex: 1;
   padding: 1rem;
   background: white;
-  border-radius: 4px;
+  border-radius: 12px;
   border-left: 6px solid transparent;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
 }
 
 .total {

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,13 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 
-  color-scheme: light dark;
-  color: rgba(24, 24, 24, 0.87);
-  background-color: #ffffff;
+:root {
+  font-family: 'Inter', sans-serif;
+  line-height: 1.5;
+  font-weight: 500;
+
+  color-scheme: light;
+  color: #111827;
+  background-color: #f9fafb;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -37,8 +39,8 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  background-color: #f9fafb;
+  color: #111827;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -49,21 +51,8 @@ h1 {
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  font-weight: 500;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 


### PR DESCRIPTION
## Summary
- add Inter font and keep light theme
- polish header action button
- refine filter buttons
- tweak search bar style
- modernize stats and event cards
- lighten list layout and add fade animation
- merge month/year filter into single control

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_685d8c447f70832fb02b00d6102a68ee