### PR TITLE
Improve server credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ Para enviar e atualizar os dados na planilha, rode o servidor Node em paralelo:
 npm run server
 ```
 
-Defina as variáveis de ambiente abaixo (por exemplo em `.env` ou diretamente no ambiente):
+Defina as variáveis de ambiente abaixo (por exemplo em `.env` ou diretamente no ambiente). Você pode usar `GOOGLE_CREDENTIALS` com o conteúdo JSON da chave ou `GOOGLE_KEY_FILE` apontando para o caminho do arquivo:
 
 ```env
 SPREADSHEET_ID=seu_id_da_planilha
+GOOGLE_CREDENTIALS='{...}' # ou
 GOOGLE_KEY_FILE=/caminho/para/google-key.json
 PORT=3001
 ```
@@ -110,8 +111,3 @@ export default tseslint.config({
   },
 })
 ```
-<<<<<<<<< Temporary merge branch 1
-npm.cmd run dev
-node dist/server/index.js
-=========
->>>>>>>>> Temporary merge branch 2

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,19 +1,32 @@
 import express, { Request, Response, RequestHandler } from "express";
 import cors from "cors";
 import { google, Auth } from "googleapis";
+import dotenv from "dotenv";
 import { Palestra } from "../types/Palestra";
+
+dotenv.config();
   
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
+const credentials = process.env.GOOGLE_CREDENTIALS;
+const keyFile = process.env.GOOGLE_KEY_FILE || process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+if (!credentials && !keyFile) {
+  console.warn(
+    "GOOGLE_CREDENTIALS or GOOGLE_KEY_FILE not provided. Attempting to use default credentials."
+  );
+}
+
 const auth = new google.auth.GoogleAuth({
-  credentials: JSON.parse(process.env.GOOGLE_CREDENTIALS!),
+  credentials: credentials ? JSON.parse(credentials) : undefined,
+  keyFile: credentials ? undefined : keyFile,
   scopes: ["https://www.googleapis.com/auth/spreadsheets"],
 });
 
-const spreadsheetId = "1ZYDkpQpep8LrxDtCuKyVVPjzTZkE4jy3PN_gKy01KkE";
+const spreadsheetId = process.env.SPREADSHEET_ID || "1ZYDkpQpep8LrxDtCuKyVVPjzTZkE4jy3PN_gKy01KkE";
 const range = "Página1!A:AH";
 
 // Function to initialize sheet headers
@@ -301,6 +314,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
   }
 }) as RequestHandler);
 
-app.listen(3001, () => {
-  console.log("Servidor rodando em http://localhost:3001");
+const port = Number(process.env.PORT) || 3001;
+app.listen(port, () => {
+  console.log(`Servidor rodando em http://localhost:${port}`);
 });


### PR DESCRIPTION
## Summary
- load environment variables with `dotenv`
- support `GOOGLE_CREDENTIALS` or `GOOGLE_KEY_FILE`
- allow spreadsheet id and port to be configured via env vars
- clean up README instructions and remove merge markers

## Testing
- `npm run lint` *(fails: SyntaxError in eslint.config.js)*
- `npm run build` *(fails: missing React and other dependencies)*
- `npm run server` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db59ab4b0832fab388188e57708e5