### PR TITLE
Allow credentials from env JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ Defina as variáveis de ambiente abaixo (por exemplo em `.env` dentro da pasta `
 
 ```env
 SPREADSHEET_ID=seu_id_da_planilha
+# Caminho para o arquivo JSON do service account ou deixe em branco se usar GOOGLE_CREDENTIALS
 GOOGLE_APPLICATION_CREDENTIALS=/caminho/para/sheets-key.json
+# Opcionalmente, em vez do caminho acima, defina as credenciais diretamente em formato JSON
+# GOOGLE_CREDENTIALS='{ "type": "service_account", ... }'
 PORT=3000
 ```
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -11,9 +11,13 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS!;
+const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+const credentialsJson = process.env.GOOGLE_CREDENTIALS;
+
 const auth = new google.auth.GoogleAuth({
-  keyFile: credentialsPath,
+  ...(credentialsJson
+    ? { credentials: JSON.parse(credentialsJson) }
+    : { keyFile: credentialsPath! }),
   scopes: ["https://www.googleapis.com/auth/spreadsheets"],
 });
 


### PR DESCRIPTION
## Summary
- use GOOGLE_CREDENTIALS when provided
- update docs with alternative auth variable

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_685db9379780832f99518b11476117f3