### PR TITLE
Add document upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Fluxo completo do dado: **Aplicação → Firebase → Google Sheets → Google 
 - Listagem e atualização do status de cada palestra
 - Gestão de pagamentos e contratantes
 - Registro de hospedagem e notas fiscais
+- Upload de documentos relacionados às palestras
 
 ## Como Executar
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -22,7 +22,7 @@ const auth = new google.auth.GoogleAuth({
 });
 
 const spreadsheetId = process.env.SPREADSHEET_ID!;
-const range = "Página1!A:AH";
+const range = "Página1!A:AI";
 
 // Function to initialize sheet headers
 async function initializeSheetHeaders() {
@@ -33,7 +33,7 @@ async function initializeSheetHeaders() {
     // Sempre atualiza os cabeçalhos para garantir que todos estejam presentes
     await sheets.spreadsheets.values.update({
       spreadsheetId,
-      range: "Página1!A1:AH1",
+      range: "Página1!A1:AI1",
       valueInputOption: "RAW",
       requestBody: {
         values: [[
@@ -70,6 +70,7 @@ async function initializeSheetHeaders() {
           "Pagamento Contratante",
           "Valor Final Recebido",
           "Custo Final",
+          "Arquivos",
           "Agendado"
         ]]
       }
@@ -143,6 +144,7 @@ app.post("/add-palestra", (async (req: Request, res: Response): Promise<void> =>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            (palestra.documentos || []).join(';'),
             "Não" // Exibe "Não" na planilha quando false
           ]]
         }
@@ -249,7 +251,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
       }
       
       // Atualiza exatamente a linha correta na planilha
-      const updateRange = `Página1!A${updateRow}:AH${updateRow}`;
+      const updateRange = `Página1!A${updateRow}:AI${updateRow}`;
       console.log('Preparando para atualizar a range:', updateRange);
       console.log('Atualizando linha:', updateRow, 'com ID:', palestra.id);
       console.log('Nome da palestra sendo atualizada:', palestra.nome);
@@ -292,6 +294,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            (palestra.documentos || []).join(';'),
             palestra.agendado ? "Sim" : "Não" // Exibe "Sim" ou "Não" na planilha
           ]]
         }

--- a/backend/types/Palestra.ts
+++ b/backend/types/Palestra.ts
@@ -33,5 +33,6 @@ export interface Palestra {
     pagamentoContratante: string
     valorFinalRecebido: number
     custoFinal: number
+    documentos?: string[]
     agendado: boolean
 }

--- a/src/components/CadastroPalestra.module.css
+++ b/src/components/CadastroPalestra.module.css
@@ -161,3 +161,12 @@
   background: #fb923c;
   color: white;
 }
+
+.fileList {
+  margin-top: 0.5rem;
+  padding-left: 1rem;
+}
+
+.fileList li {
+  list-style: disc;
+}

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -1,7 +1,8 @@
 // src/components/CadastroPalestra.tsx
 import { useState, FormEvent, useEffect } from 'react'
-import { db } from '../firebase'
+import { db, storage } from '../firebase'
 import { collection, updateDoc, doc } from 'firebase/firestore'
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import { Palestra } from '../types/Palestra'
 import styles from './CadastroPalestra.module.css'
 import {v4 as uuidv4} from "uuid";
@@ -49,12 +50,14 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
     pagamentoContratante: '',
     valorFinalRecebido: 0,
     custoFinal: 0,
+    documentos: [],
     agendado: false,
   })
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [tab, setTab] = useState<'basico' | 'financeiro' | 'viagem'>('basico')
+  const [files, setFiles] = useState<File[]>([])
 
   useEffect(() => {
     if (palestraSelecionada) {
@@ -94,8 +97,10 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         pagamentoContratante: '',
         valorFinalRecebido: 0,
         custoFinal: 0,
+        documentos: [],
         agendado: false,
       })
+      setFiles([])
     }
   }, [palestraSelecionada])
 
@@ -129,6 +134,12 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       ...prev,
       [name]: type === 'checkbox' ? target.checked : value
     }))
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      setFiles(Array.from(e.target.files))
+    }
   }
 
   const validateForm = (): boolean => {
@@ -169,12 +180,25 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
 
     setLoading(true)
     try {
+      const idEvento = palestraSelecionada ? palestraSelecionada.id! : uuidv4();
+
+      let documentosUrls = form.documentos || [];
+      if (files.length > 0) {
+        const uploadPromises = files.map(async (file) => {
+          const fileRef = ref(storage, `palestras/${idEvento}/${file.name}`)
+          await uploadBytes(fileRef, file)
+          return await getDownloadURL(fileRef)
+        })
+        const uploaded = await Promise.all(uploadPromises)
+        documentosUrls = [...documentosUrls, ...uploaded]
+      }
+
       if (palestraSelecionada) {
         // Atualiza palestra existente (mantém o id atual)
-        const palestraData = { ...form, id: palestraSelecionada.id };
+        const palestraData = { ...form, id: idEvento, documentos: documentosUrls };
         console.log('ID enviado para edição:', palestraData.id);
         // Usa o id do Firestore salvo em palestraSelecionada.id
-        const docRef = doc(collection(db, 'palestras'), palestraSelecionada.id);
+        const docRef = doc(collection(db, 'palestras'), idEvento);
         await updateDoc(docRef, palestraData);
         // Atualiza no Google Sheets
         try {
@@ -193,11 +217,10 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         }
       } else {
         // Cria nova palestra com id único para o Google Sheets
-        const uuid = uuidv4();
-        const novaPalestra = { ...form, id: uuid };
+        const novaPalestra = { ...form, id: idEvento, documentos: documentosUrls };
 
-        const docRef = doc(db, 'palestras', uuid); // Cria uma referência com ID explícito
-        await setDoc(docRef, { ...form, id: uuid }); // Usa setDoc em vez de addDoc
+        const docRef = doc(db, 'palestras', idEvento); // Cria uma referência com ID explícito
+        await setDoc(docRef, novaPalestra); // Usa setDoc em vez de addDoc
         // Envia para o Google Sheets
         try {
             const response = await fetch(`${API_URL}/add-palestra`, {
@@ -249,6 +272,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         pagamentoContratante: '',
         valorFinalRecebido: 0,
         custoFinal: 0,
+        documentos: [],
         agendado: false,
       })
       
@@ -374,6 +398,20 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
           />
         </div>
       )}
+
+      <div className={styles.field}>
+        <label>Documentos:</label>
+        <input type="file" multiple onChange={handleFileChange} />
+        {form.documentos && form.documentos.length > 0 && (
+          <ul className={styles.fileList}>
+            {form.documentos.map((url, idx) => (
+              <li key={idx}>
+                <a href={url} target="_blank" rel="noopener noreferrer">Arquivo {idx + 1}</a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
 
       </>
       )}

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 // src/firebase.ts
 import { initializeApp } from 'firebase/app'
 import { getFirestore } from 'firebase/firestore'
+import { getStorage } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,3 +14,4 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig)
 export const db = getFirestore(app)
+export const storage = getStorage(app)

--- a/src/types/Palestra.ts
+++ b/src/types/Palestra.ts
@@ -33,5 +33,6 @@ export interface Palestra {
     pagamentoContratante: string
     valorFinalRecebido: number
     custoFinal: number
+    documentos?: string[]
     agendado: boolean
 }


### PR DESCRIPTION
## Summary
- support Firebase storage in client
- allow uploading document files when creating or editing an event
- expose storage via firebase config
- store document links in Firestore and Google Sheets
- style list of attached documents

## Testing
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run build` *(fails: cannot find module and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862c118ae3c832f9bd718f210b4eda7