### PR TITLE
Add document upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Fluxo completo do dado: **Aplicação → Firebase → Google Sheets → Google 
 - Listagem e atualização do status de cada palestra
 - Gestão de pagamentos e contratantes
 - Registro de hospedagem e notas fiscais
+- Upload de documentos relacionados às palestras
 
 ## Como Executar
 
@@ -59,7 +60,10 @@ GOOGLE_APPLICATION_CREDENTIALS=/caminho/para/sheets-key.json
 # GOOGLE_CREDENTIALS='{ "type": "service_account", ... }'
 PORT=3000
 VITE_BACKEND_URL=http://localhost:3001
+FIREBASE_STORAGE_BUCKET=seu_storage_bucket
 ```
+
+O backend utiliza `FIREBASE_STORAGE_BUCKET` para fazer upload dos documentos da palestra.
 
 # React + TypeScript + Vite
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,15 +1,26 @@
-import express, { Request, Response, RequestHandler } from "express";
+import express, { Request, Response, RequestHandler, Express } from "express";
 import cors from "cors";
 import { google, Auth } from "googleapis";
 import { Palestra } from "./types/Palestra";
 import path from "path";
 import dotenv from "dotenv";
+import admin from "firebase-admin";
+import multer from "multer";
+import { v4 as uuidv4 } from "uuid";
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
   
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+const upload = multer({ storage: multer.memoryStorage() });
+
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET || process.env.VITE_FIREBASE_STORAGE_BUCKET,
+});
+const bucket = admin.storage().bucket();
 
 const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
 const credentialsJson = process.env.GOOGLE_CREDENTIALS;
@@ -22,7 +33,7 @@ const auth = new google.auth.GoogleAuth({
 });
 
 const spreadsheetId = process.env.SPREADSHEET_ID!;
-const range = "Página1!A:AH";
+const range = "Página1!A:AI";
 
 // Function to initialize sheet headers
 async function initializeSheetHeaders() {
@@ -33,7 +44,7 @@ async function initializeSheetHeaders() {
     // Sempre atualiza os cabeçalhos para garantir que todos estejam presentes
     await sheets.spreadsheets.values.update({
       spreadsheetId,
-      range: "Página1!A1:AH1",
+      range: "Página1!A1:AI1",
       valueInputOption: "RAW",
       requestBody: {
         values: [[
@@ -70,6 +81,7 @@ async function initializeSheetHeaders() {
           "Pagamento Contratante",
           "Valor Final Recebido",
           "Custo Final",
+          "Arquivos",
           "Agendado"
         ]]
       }
@@ -143,6 +155,7 @@ app.post("/add-palestra", (async (req: Request, res: Response): Promise<void> =>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            (palestra.documentos || []).join(';'),
             "Não" // Exibe "Não" na planilha quando false
           ]]
         }
@@ -154,6 +167,34 @@ app.post("/add-palestra", (async (req: Request, res: Response): Promise<void> =>
     res.status(500).json({ message: "Erro ao adicionar palestra.", error: String(error) });
   }
 }) as RequestHandler);
+
+app.post("/upload-document", upload.array("files"), async (req: Request, res: Response) => {
+  try {
+    const idEvento = req.body.idEvento;
+    const files = req.files as Express.Multer.File[];
+    if (!files || files.length === 0) {
+      res.status(400).json({ message: "Nenhum arquivo enviado" });
+      return;
+    }
+    const urls: string[] = [];
+    for (const file of files) {
+      const filePath = `palestras/${idEvento}/${file.originalname}`;
+      const token = uuidv4();
+      await bucket.file(filePath).save(file.buffer, {
+        metadata: {
+          contentType: file.mimetype,
+          metadata: { firebaseStorageDownloadTokens: token },
+        },
+      });
+      const url = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(filePath)}?alt=media&token=${token}`;
+      urls.push(url);
+    }
+    res.json({ urls });
+  } catch (err) {
+    console.error("Erro no upload:", err);
+    res.status(500).json({ message: "Erro ao enviar arquivo", error: String(err) });
+  }
+});
 
 app.post("/update-palestra", (async (req: Request, res: Response): Promise<void> => {
   try {
@@ -249,7 +290,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
       }
       
       // Atualiza exatamente a linha correta na planilha
-      const updateRange = `Página1!A${updateRow}:AH${updateRow}`;
+      const updateRange = `Página1!A${updateRow}:AI${updateRow}`;
       console.log('Preparando para atualizar a range:', updateRange);
       console.log('Atualizando linha:', updateRow, 'com ID:', palestra.id);
       console.log('Nome da palestra sendo atualizada:', palestra.nome);
@@ -292,6 +333,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            (palestra.documentos || []).join(';'),
             palestra.agendado ? "Sim" : "Não" // Exibe "Sim" ou "Não" na planilha
           ]]
         }

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "googleapis": "^118.0.0"
+    "googleapis": "^118.0.0",
+    "firebase-admin": "^12.0.0",
+    "multer": "^1.4.5"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/backend/types/Palestra.ts
+++ b/backend/types/Palestra.ts
@@ -33,5 +33,6 @@ export interface Palestra {
     pagamentoContratante: string
     valorFinalRecebido: number
     custoFinal: number
+    documentos?: string[]
     agendado: boolean
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "express": "^5.1.0",
     "firebase": "^11.6.1",
     "googleapis": "^148.0.0",
+    "firebase-admin": "^12.0.0",
+    "multer": "^1.4.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "uuid": "^11.1.0"

--- a/src/components/CadastroPalestra.module.css
+++ b/src/components/CadastroPalestra.module.css
@@ -161,3 +161,12 @@
   background: #fb923c;
   color: white;
 }
+
+.fileList {
+  margin-top: 0.5rem;
+  padding-left: 1rem;
+}
+
+.fileList li {
+  list-style: disc;
+}

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -49,12 +49,14 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
     pagamentoContratante: '',
     valorFinalRecebido: 0,
     custoFinal: 0,
+    documentos: [],
     agendado: false,
   })
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [tab, setTab] = useState<'basico' | 'financeiro' | 'viagem'>('basico')
+  const [files, setFiles] = useState<File[]>([])
 
   useEffect(() => {
     if (palestraSelecionada) {
@@ -94,8 +96,10 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         pagamentoContratante: '',
         valorFinalRecebido: 0,
         custoFinal: 0,
+        documentos: [],
         agendado: false,
       })
+      setFiles([])
     }
   }, [palestraSelecionada])
 
@@ -129,6 +133,12 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       ...prev,
       [name]: type === 'checkbox' ? target.checked : value
     }))
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      setFiles(Array.from(e.target.files))
+    }
   }
 
   const validateForm = (): boolean => {
@@ -169,12 +179,35 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
 
     setLoading(true)
     try {
+      const idEvento = palestraSelecionada ? palestraSelecionada.id! : uuidv4();
+
+      let documentosUrls = form.documentos || [];
+      if (files.length > 0) {
+        const formDataUpload = new FormData();
+        formDataUpload.append('idEvento', idEvento);
+        files.forEach((f) => formDataUpload.append('files', f));
+        try {
+          const uploadResp = await fetch(`${API_URL}/upload-document`, {
+            method: 'POST',
+            body: formDataUpload,
+          });
+          if (uploadResp.ok) {
+            const data = await uploadResp.json();
+            documentosUrls = [...documentosUrls, ...data.urls];
+          } else {
+            console.error('Falha ao enviar arquivos');
+          }
+        } catch (uploadErr) {
+          console.error('Erro no upload:', uploadErr);
+        }
+      }
+
       if (palestraSelecionada) {
         // Atualiza palestra existente (mantém o id atual)
-        const palestraData = { ...form, id: palestraSelecionada.id };
+        const palestraData = { ...form, id: idEvento, documentos: documentosUrls };
         console.log('ID enviado para edição:', palestraData.id);
         // Usa o id do Firestore salvo em palestraSelecionada.id
-        const docRef = doc(collection(db, 'palestras'), palestraSelecionada.id);
+        const docRef = doc(collection(db, 'palestras'), idEvento);
         await updateDoc(docRef, palestraData);
         // Atualiza no Google Sheets
         try {
@@ -193,11 +226,10 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         }
       } else {
         // Cria nova palestra com id único para o Google Sheets
-        const uuid = uuidv4();
-        const novaPalestra = { ...form, id: uuid };
+        const novaPalestra = { ...form, id: idEvento, documentos: documentosUrls };
 
-        const docRef = doc(db, 'palestras', uuid); // Cria uma referência com ID explícito
-        await setDoc(docRef, { ...form, id: uuid }); // Usa setDoc em vez de addDoc
+        const docRef = doc(db, 'palestras', idEvento); // Cria uma referência com ID explícito
+        await setDoc(docRef, novaPalestra); // Usa setDoc em vez de addDoc
         // Envia para o Google Sheets
         try {
             const response = await fetch(`${API_URL}/add-palestra`, {
@@ -249,6 +281,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         pagamentoContratante: '',
         valorFinalRecebido: 0,
         custoFinal: 0,
+        documentos: [],
         agendado: false,
       })
       
@@ -374,6 +407,20 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
           />
         </div>
       )}
+
+      <div className={styles.field}>
+        <label>Documentos:</label>
+        <input type="file" multiple onChange={handleFileChange} />
+        {form.documentos && form.documentos.length > 0 && (
+          <ul className={styles.fileList}>
+            {form.documentos.map((url, idx) => (
+              <li key={idx}>
+                <a href={url} target="_blank" rel="noopener noreferrer">Arquivo {idx + 1}</a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
 
       </>
       )}

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 // src/firebase.ts
 import { initializeApp } from 'firebase/app'
 import { getFirestore } from 'firebase/firestore'
+import { getStorage } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,3 +14,4 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig)
 export const db = getFirestore(app)
+export const storage = getStorage(app)

--- a/src/types/Palestra.ts
+++ b/src/types/Palestra.ts
@@ -33,5 +33,6 @@ export interface Palestra {
     pagamentoContratante: string
     valorFinalRecebido: number
     custoFinal: number
+    documentos?: string[]
     agendado: boolean
 }


### PR DESCRIPTION
## Summary
- support Firebase storage in client
- allow uploading document files when creating or editing an event
- expose storage via firebase config
- store document links in Firestore and Google Sheets
- style list of attached documents
- upload files through backend instead of direct client upload

## Testing
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run build` *(fails: cannot find module and type errors)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6862c118ae3c832f9bd718f210b4eda7