### PR TITLE
Enable multiple document uploads

### DIFF
--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -1,13 +1,14 @@
 // src/components/CadastroPalestra.tsx
 import { useState, FormEvent, useEffect } from 'react'
-import { db } from '../firebase'
+import { db, storage } from '../firebase'
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import { collection, updateDoc, doc } from 'firebase/firestore'
 import { Palestra } from '../types/Palestra'
 import styles from './CadastroPalestra.module.css'
 import {v4 as uuidv4} from "uuid";
 
 import { setDoc } from 'firebase/firestore'; // Adicione esta importação
-const API_URL = import.meta.env.VITE_BACKEND_URL || ""
+const API_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000'
 interface CadastroPalestraProps {
   palestraSelecionada: Palestra | null
   onPalestraSalva: () => void
@@ -139,10 +140,6 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || [])
     setSelectedFiles(files)
-    setForm(prev => ({
-      ...prev,
-      documentos: files.map(f => f.name)
-    }))
   }
 
   const validateForm = (): boolean => {
@@ -176,16 +173,28 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
-    
+
     if (!validateForm()) {
       return
     }
 
     setLoading(true)
     try {
+      let uploadedUrls: string[] = []
+      if (selectedFiles.length > 0) {
+        uploadedUrls = await Promise.all(
+          selectedFiles.map(async file => {
+            const fileRef = ref(storage, `documentos/${uuidv4()}-${file.name}`)
+            await uploadBytes(fileRef, file)
+            return await getDownloadURL(fileRef)
+          })
+        )
+      }
+
       if (palestraSelecionada) {
         // Atualiza palestra existente (mantém o id atual)
-        const palestraData = { ...form, id: palestraSelecionada.id };
+        const documentosAtualizados = [...form.documentos, ...uploadedUrls]
+        const palestraData = { ...form, documentos: documentosAtualizados, id: palestraSelecionada.id };
         console.log('ID enviado para edição:', palestraData.id);
         // Usa o id do Firestore salvo em palestraSelecionada.id
         const docRef = doc(collection(db, 'palestras'), palestraSelecionada.id);
@@ -208,10 +217,11 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       } else {
         // Cria nova palestra com id único para o Google Sheets
         const uuid = uuidv4();
-        const novaPalestra = { ...form, id: uuid };
+        const documentosAtualizados = [...form.documentos, ...uploadedUrls]
+        const novaPalestra = { ...form, documentos: documentosAtualizados, id: uuid };
 
         const docRef = doc(db, 'palestras', uuid); // Cria uma referência com ID explícito
-        await setDoc(docRef, { ...form, id: uuid }); // Usa setDoc em vez de addDoc
+        await setDoc(docRef, novaPalestra); // Usa setDoc em vez de addDoc
         // Envia para o Google Sheets
         try {
             const response = await fetch(`${API_URL}/add-palestra`, {
@@ -375,8 +385,8 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
               ? selectedFiles.map(file => (
                   <li key={file.name}>{file.name}</li>
                 ))
-              : form.documentos.map(name => (
-                  <li key={name}>{name}</li>
+              : form.documentos.map(url => (
+                  <li key={url}>{url.split('/').pop()}</li>
                 ))}
           </ul>
         )}

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 // src/firebase.ts
 import { initializeApp } from 'firebase/app'
 import { getFirestore } from 'firebase/firestore'
+import { getStorage } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,3 +14,4 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig)
 export const db = getFirestore(app)
+export const storage = getStorage(app)


### PR DESCRIPTION
## Summary
- add Firebase storage support
- allow uploading multiple documents when saving a palestra
- show attached file names
- default API URL to localhost

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6862dbcbc278832f9117c590407b2337