### PR TITLE
Enable multiple document uploads

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -22,7 +22,7 @@ const auth = new google.auth.GoogleAuth({
 });
 
 const spreadsheetId = process.env.SPREADSHEET_ID!;
-const range = "Página1!A:AH";
+const range = "Página1!A:AI";
 
 // Function to initialize sheet headers
 async function initializeSheetHeaders() {
@@ -33,7 +33,7 @@ async function initializeSheetHeaders() {
     // Sempre atualiza os cabeçalhos para garantir que todos estejam presentes
     await sheets.spreadsheets.values.update({
       spreadsheetId,
-      range: "Página1!A1:AH1",
+      range: "Página1!A1:AI1",
       valueInputOption: "RAW",
       requestBody: {
         values: [[
@@ -70,6 +70,7 @@ async function initializeSheetHeaders() {
           "Pagamento Contratante",
           "Valor Final Recebido",
           "Custo Final",
+          "Documentos",
           "Agendado"
         ]]
       }
@@ -97,6 +98,7 @@ app.post("/add-palestra", (async (req: Request, res: Response): Promise<void> =>
 
     const palestra: Palestra = {
       ...req.body,
+      documentos: req.body.documentos || [],
       agendado: false // Garante que sempre inicie como false
     };
 
@@ -143,6 +145,7 @@ app.post("/add-palestra", (async (req: Request, res: Response): Promise<void> =>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            (palestra.documentos || []).join(', '),
             "Não" // Exibe "Não" na planilha quando false
           ]]
         }
@@ -169,6 +172,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
 
     const palestra: Palestra = {
       ...req.body,
+      documentos: req.body.documentos || [],
       agendado: req.body.agendado || false // Garante que sempre tenha um valor
     };
 
@@ -249,7 +253,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
       }
       
       // Atualiza exatamente a linha correta na planilha
-      const updateRange = `Página1!A${updateRow}:AH${updateRow}`;
+      const updateRange = `Página1!A${updateRow}:AI${updateRow}`;
       console.log('Preparando para atualizar a range:', updateRange);
       console.log('Atualizando linha:', updateRow, 'com ID:', palestra.id);
       console.log('Nome da palestra sendo atualizada:', palestra.nome);
@@ -292,6 +296,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            (palestra.documentos || []).join(', '),
             palestra.agendado ? "Sim" : "Não" // Exibe "Sim" ou "Não" na planilha
           ]]
         }

--- a/backend/types/Palestra.ts
+++ b/backend/types/Palestra.ts
@@ -33,5 +33,6 @@ export interface Palestra {
     pagamentoContratante: string
     valorFinalRecebido: number
     custoFinal: number
+    documentos: string[]
     agendado: boolean
 }

--- a/src/components/CadastroPalestra.module.css
+++ b/src/components/CadastroPalestra.module.css
@@ -161,3 +161,10 @@
   background: #fb923c;
   color: white;
 }
+
+.fileList {
+  margin-top: 0.5rem;
+  list-style: disc;
+  padding-left: 1.5rem;
+  color: #333;
+}

--- a/src/components/CadastroPalestra.module.css
+++ b/src/components/CadastroPalestra.module.css
@@ -168,3 +168,11 @@
   padding-left: 1.5rem;
   color: #333;
 }
+
+.removeFileBtn {
+  margin-left: 0.5rem;
+  background: none;
+  border: none;
+  color: #dc3545;
+  cursor: pointer;
+}

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -49,8 +49,11 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
     pagamentoContratante: '',
     valorFinalRecebido: 0,
     custoFinal: 0,
+    documentos: [],
     agendado: false,
   })
+
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -94,8 +97,10 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         pagamentoContratante: '',
         valorFinalRecebido: 0,
         custoFinal: 0,
+        documentos: [],
         agendado: false,
       })
+      setSelectedFiles([])
     }
   }, [palestraSelecionada])
 
@@ -128,6 +133,15 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
     setForm(prev => ({
       ...prev,
       [name]: type === 'checkbox' ? target.checked : value
+    }))
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || [])
+    setSelectedFiles(files)
+    setForm(prev => ({
+      ...prev,
+      documentos: files.map(f => f.name)
     }))
   }
 
@@ -249,8 +263,10 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         pagamentoContratante: '',
         valorFinalRecebido: 0,
         custoFinal: 0,
+        documentos: [],
         agendado: false,
       })
+      setSelectedFiles([])
       
       // Notifica o componente pai
       onPalestraSalva()
@@ -348,6 +364,22 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       <div className={styles.field}>
         <label>Observações:</label>
         <textarea name="observacoes" value={form.observacoes} onChange={handleChange} />
+      </div>
+
+      <div className={styles.field}>
+        <label>Anexar Documentos:</label>
+        <input type="file" multiple onChange={handleFileChange} />
+        {(selectedFiles.length > 0 || form.documentos.length > 0) && (
+          <ul className={styles.fileList}>
+            {selectedFiles.length > 0
+              ? selectedFiles.map(file => (
+                  <li key={file.name}>{file.name}</li>
+                ))
+              : form.documentos.map(name => (
+                  <li key={name}>{name}</li>
+                ))}
+          </ul>
+        )}
       </div>
 
       <div className={styles.field}>

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -1,13 +1,14 @@
 // src/components/CadastroPalestra.tsx
 import { useState, FormEvent, useEffect } from 'react'
-import { db } from '../firebase'
+import { db, storage } from '../firebase'
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import { collection, updateDoc, doc } from 'firebase/firestore'
 import { Palestra } from '../types/Palestra'
 import styles from './CadastroPalestra.module.css'
 import {v4 as uuidv4} from "uuid";
 
 import { setDoc } from 'firebase/firestore'; // Adicione esta importação
-const API_URL = import.meta.env.VITE_BACKEND_URL || ""
+const API_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000'
 interface CadastroPalestraProps {
   palestraSelecionada: Palestra | null
   onPalestraSalva: () => void
@@ -138,10 +139,17 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || [])
-    setSelectedFiles(files)
+    setSelectedFiles(prev => [...prev, ...files])
+  }
+
+  const removeSelectedFile = (index: number) => {
+    setSelectedFiles(prev => prev.filter((_, i) => i !== index))
+  }
+
+  const removeExistingDocumento = (index: number) => {
     setForm(prev => ({
       ...prev,
-      documentos: files.map(f => f.name)
+      documentos: prev.documentos.filter((_, i) => i !== index),
     }))
   }
 
@@ -176,16 +184,28 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
-    
+
     if (!validateForm()) {
       return
     }
 
     setLoading(true)
     try {
+      let uploadedUrls: string[] = []
+      if (selectedFiles.length > 0) {
+        uploadedUrls = await Promise.all(
+          selectedFiles.map(async file => {
+            const fileRef = ref(storage, `documentos/${uuidv4()}-${file.name}`)
+            await uploadBytes(fileRef, file)
+            return await getDownloadURL(fileRef)
+          })
+        )
+      }
+
       if (palestraSelecionada) {
         // Atualiza palestra existente (mantém o id atual)
-        const palestraData = { ...form, id: palestraSelecionada.id };
+        const documentosAtualizados = [...form.documentos, ...uploadedUrls]
+        const palestraData = { ...form, documentos: documentosAtualizados, id: palestraSelecionada.id };
         console.log('ID enviado para edição:', palestraData.id);
         // Usa o id do Firestore salvo em palestraSelecionada.id
         const docRef = doc(collection(db, 'palestras'), palestraSelecionada.id);
@@ -208,10 +228,11 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       } else {
         // Cria nova palestra com id único para o Google Sheets
         const uuid = uuidv4();
-        const novaPalestra = { ...form, id: uuid };
+        const documentosAtualizados = [...form.documentos, ...uploadedUrls]
+        const novaPalestra = { ...form, documentos: documentosAtualizados, id: uuid };
 
         const docRef = doc(db, 'palestras', uuid); // Cria uma referência com ID explícito
-        await setDoc(docRef, { ...form, id: uuid }); // Usa setDoc em vez de addDoc
+        await setDoc(docRef, novaPalestra); // Usa setDoc em vez de addDoc
         // Envia para o Google Sheets
         try {
             const response = await fetch(`${API_URL}/add-palestra`, {
@@ -371,13 +392,30 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         <input type="file" multiple onChange={handleFileChange} />
         {(selectedFiles.length > 0 || form.documentos.length > 0) && (
           <ul className={styles.fileList}>
-            {selectedFiles.length > 0
-              ? selectedFiles.map(file => (
-                  <li key={file.name}>{file.name}</li>
-                ))
-              : form.documentos.map(name => (
-                  <li key={name}>{name}</li>
-                ))}
+            {form.documentos.map((url, idx) => (
+              <li key={url}>
+                {url.split('/').pop()}
+                <button
+                  type="button"
+                  className={styles.removeFileBtn}
+                  onClick={() => removeExistingDocumento(idx)}
+                >
+                  Remover
+                </button>
+              </li>
+            ))}
+            {selectedFiles.map((file, idx) => (
+              <li key={file.name + idx}>
+                {file.name}
+                <button
+                  type="button"
+                  className={styles.removeFileBtn}
+                  onClick={() => removeSelectedFile(idx)}
+                >
+                  Remover
+                </button>
+              </li>
+            ))}
           </ul>
         )}
       </div>

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 // src/firebase.ts
 import { initializeApp } from 'firebase/app'
 import { getFirestore } from 'firebase/firestore'
+import { getStorage } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,3 +14,4 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig)
 export const db = getFirestore(app)
+export const storage = getStorage(app)

--- a/src/types/Palestra.ts
+++ b/src/types/Palestra.ts
@@ -33,5 +33,6 @@ export interface Palestra {
     pagamentoContratante: string
     valorFinalRecebido: number
     custoFinal: number
+    documentos: string[]
     agendado: boolean
 }


### PR DESCRIPTION
## Summary
- add Firebase storage support
- allow uploading multiple documents when saving a palestra
- show attached file names
- default API URL to localhost
- allow removing uploaded documents before saving

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*


------
https://chatgpt.com/codex/tasks/task_e_6862dbcbc278832f9117c590407b2337