### PR TITLE
Add resumo field

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -22,7 +22,7 @@ const auth = new google.auth.GoogleAuth({
 });
 
 const spreadsheetId = process.env.SPREADSHEET_ID!;
-const range = "Página1!A:AH";
+const range = "Página1!A:AI";
 
 // Function to initialize sheet headers
 async function initializeSheetHeaders() {
@@ -70,6 +70,7 @@ async function initializeSheetHeaders() {
           "Pagamento Contratante",
           "Valor Final Recebido",
           "Custo Final",
+          "Resumo",
           "Agendado"
         ]]
       }
@@ -143,6 +144,7 @@ app.post("/add-palestra", (async (req: Request, res: Response): Promise<void> =>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            palestra.resumo,
             "Não" // Exibe "Não" na planilha quando false
           ]]
         }
@@ -292,6 +294,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            palestra.resumo,
             palestra.agendado ? "Sim" : "Não" // Exibe "Sim" ou "Não" na planilha
           ]]
         }

--- a/backend/types/Palestra.ts
+++ b/backend/types/Palestra.ts
@@ -9,6 +9,7 @@ export interface Palestra {
     dataMarcada: string
     horarioEvento: string
     local: string
+    resumo: string
     observacoes: string
     infoIda: string
     infoRetorno: string

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -25,6 +25,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
     dataMarcada: '',
     horarioEvento: '',
     local: '',
+    resumo: '',
     observacoes: '',
     infoIda: '',
     infoRetorno: '',
@@ -70,6 +71,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         dataMarcada: '',
         horarioEvento: '',
         local: '',
+        resumo: '',
         observacoes: '',
         infoIda: '',
         infoRetorno: '',
@@ -225,6 +227,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         dataMarcada: '',
         horarioEvento: '',
         local: '',
+        resumo: '',
         observacoes: '',
         infoIda: '',
         infoRetorno: '',
@@ -344,6 +347,10 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       <div className={styles.field}>
         <label>Horário do Evento:</label>
         <input type="time" name="horarioEvento" value={form.horarioEvento} onChange={handleChange} />
+      </div>
+      <div className={styles.field}>
+        <label>Resumo da Palestra:</label>
+        <textarea name="resumo" value={form.resumo} onChange={handleChange} />
       </div>
       <div className={styles.field}>
         <label>Observações:</label>

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -104,3 +104,18 @@
   background: #ef4444;
   color: white;
 }
+
+.resumo {
+  display: none;
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 1rem;
+  border-radius: 12px;
+  overflow-y: auto;
+}
+
+.card:hover .resumo {
+  display: block;
+}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -44,6 +44,9 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes }: Ev
         <button className={styles.edit} onClick={() => onEditar(event)}>✏️ Editar</button>
         <button className={styles.delete} onClick={() => onExcluir(event)}>🗑️ Excluir</button>
       </div>
+      {event.resumo && (
+        <div className={styles.resumo}>{event.resumo}</div>
+      )}
     </div>
   )
 }

--- a/src/types/Palestra.ts
+++ b/src/types/Palestra.ts
@@ -9,6 +9,7 @@ export interface Palestra {
     dataMarcada: string
     horarioEvento: string
     local: string
+    resumo: string
     observacoes: string
     infoIda: string
     infoRetorno: string


### PR DESCRIPTION
## Summary
- add `resumo` property to Palestra types
- store summary in Firestore and Sheets
- show resumo when hovering EventCard
- expose resumo field in CadastroPalestra form

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6862fdffa060832f8e5bb41c57e8e8fc