### PR TITLE
Add resumo field and hover display

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -22,7 +22,7 @@ const auth = new google.auth.GoogleAuth({
 });
 
 const spreadsheetId = process.env.SPREADSHEET_ID!;
-const range = "Página1!A:AH";
+const range = "Página1!A:AI";
 
 // Function to initialize sheet headers
 async function initializeSheetHeaders() {
@@ -33,7 +33,7 @@ async function initializeSheetHeaders() {
     // Sempre atualiza os cabeçalhos para garantir que todos estejam presentes
     await sheets.spreadsheets.values.update({
       spreadsheetId,
-      range: "Página1!A1:AH1",
+      range: "Página1!A1:AI1",
       valueInputOption: "RAW",
       requestBody: {
         values: [[
@@ -70,6 +70,7 @@ async function initializeSheetHeaders() {
           "Pagamento Contratante",
           "Valor Final Recebido",
           "Custo Final",
+          "Resumo",
           "Agendado"
         ]]
       }
@@ -143,6 +144,7 @@ app.post("/add-palestra", (async (req: Request, res: Response): Promise<void> =>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            palestra.resumo,
             "Não" // Exibe "Não" na planilha quando false
           ]]
         }
@@ -249,7 +251,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
       }
       
       // Atualiza exatamente a linha correta na planilha
-      const updateRange = `Página1!A${updateRow}:AH${updateRow}`;
+      const updateRange = `Página1!A${updateRow}:AI${updateRow}`;
       console.log('Preparando para atualizar a range:', updateRange);
       console.log('Atualizando linha:', updateRow, 'com ID:', palestra.id);
       console.log('Nome da palestra sendo atualizada:', palestra.nome);
@@ -292,6 +294,7 @@ app.post("/update-palestra", (async (req: Request, res: Response): Promise<void>
             palestra.pagamentoContratante,
             palestra.valorFinalRecebido,
             palestra.custoFinal,
+            palestra.resumo,
             palestra.agendado ? "Sim" : "Não" // Exibe "Sim" ou "Não" na planilha
           ]]
         }

--- a/backend/types/Palestra.ts
+++ b/backend/types/Palestra.ts
@@ -10,6 +10,7 @@ export interface Palestra {
     horarioEvento: string
     local: string
     observacoes: string
+    resumo: string
     infoIda: string
     infoRetorno: string
     hospedagemInclusa: boolean

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -26,6 +26,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
     horarioEvento: '',
     local: '',
     observacoes: '',
+    resumo: '',
     infoIda: '',
     infoRetorno: '',
     humanoide: false,
@@ -71,6 +72,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         horarioEvento: '',
         local: '',
         observacoes: '',
+        resumo: '',
         infoIda: '',
         infoRetorno: '',
         humanoide: false,
@@ -226,6 +228,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         horarioEvento: '',
         local: '',
         observacoes: '',
+        resumo: '',
         infoIda: '',
         infoRetorno: '',
         humanoide: false,
@@ -348,6 +351,15 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       <div className={styles.field}>
         <label>Observações:</label>
         <textarea name="observacoes" value={form.observacoes} onChange={handleChange} />
+      </div>
+      <div className={styles.field}>
+        <label>Resumo:</label>
+        <textarea
+          name="resumo"
+          value={form.resumo}
+          onChange={handleChange}
+          placeholder="Escreva um breve resumo da palestra"
+        />
       </div>
 
       <div className={styles.field}>

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -73,6 +73,20 @@
   color: #22c55e;
 }
 
+.resumo {
+  display: none;
+  font-size: 0.875rem;
+  color: #374151;
+  background: #f9fafb;
+  padding: 0.5rem;
+  border-radius: 8px;
+  margin-top: 0.25rem;
+}
+
+.card:hover .resumo {
+  display: block;
+}
+
 .actions {
   display: none;
   gap: 0.5rem;

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -39,6 +39,9 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes }: Ev
         <div>R$ {event.valorVenda}</div>
         <div className={styles.lucro}>Lucro: R$ {event.lucroFinal}</div>
       </div>
+      {event.resumo && (
+        <p className={styles.resumo}>{event.resumo}</p>
+      )}
       <div className={styles.actions}>
         <button className={styles.details} onClick={() => onDetalhes(event)}>👁️ Ver Detalhes</button>
         <button className={styles.edit} onClick={() => onEditar(event)}>✏️ Editar</button>

--- a/src/types/Palestra.ts
+++ b/src/types/Palestra.ts
@@ -10,6 +10,7 @@ export interface Palestra {
     horarioEvento: string
     local: string
     observacoes: string
+    resumo: string
     infoIda: string
     infoRetorno: string
     hospedagemInclusa: boolean


### PR DESCRIPTION
## Summary
- add `resumo` to Palestra types
- allow editing `resumo` in the form
- show resumo on event card hover
- handle resumo in backend and Google Sheets

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68630156cfe0832f9c57089920e966e1