### PR TITLE
Adiciona cores alternadas por mês e ícone de relógio

### DIFF
--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -10,6 +10,10 @@
   transition: transform 0.5s ease, box-shadow 0.5s ease;
 }
 
+.gray {
+  background: #f3f4f6;
+}
+
 .card:hover {
   transition: transform 0.5s ease, box-shadow 0.5s ease;
   transform: translateY(-2px) scale(1.02);

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -6,6 +6,7 @@ interface EventCardProps {
   onEditar: (p: Palestra) => void
   onExcluir: (p: Palestra) => void
   onDetalhes: (p: Palestra) => void
+  gray?: boolean
 }
 
 function badgeColor(tipo: string) {
@@ -19,11 +20,18 @@ function badgeColor(tipo: string) {
   }
 }
 
-export default function EventCard({ event, onEditar, onExcluir, onDetalhes }: EventCardProps) {
+export default function EventCard({ event, onEditar, onExcluir, onDetalhes, gray }: EventCardProps) {
   const data = new Date(event.dataMarcada + 'T12:00:00')
   const future = data >= new Date()
+  const formattedDate = data
+    .toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    })
+    .replace(/\//g, '-')
   return (
-    <div className={styles.card}>
+    <div className={`${styles.card} ${gray ? styles.gray : ''}`}>
       <div className={styles.header}>
         <h3>{event.nome}</h3>
         <span className={`${styles.badge} ${badgeColor(event.tipo)}`}>{event.tipo}</span>
@@ -31,7 +39,12 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes }: Ev
         <span className={`${styles.badge} ${future ? styles.proximo : styles.passado}`}>{future ? 'Próximo' : 'Passado'}</span>
       </div>
       <ul className={styles.info}>
-        <li><span className={styles.icon}>📅</span>{event.dataMarcada} {event.horarioEvento}</li>
+        <li>
+          <span className={styles.icon}>📅</span>
+          {formattedDate}
+          <span className={styles.icon}>🕒</span>
+          {event.horarioEvento}
+        </li>
         <li><span className={styles.icon}>📍</span>{event.local}</li>
         <li><span className={styles.icon}>🏷️</span>{event.tipo}</li>
       </ul>

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -115,6 +115,8 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
     months.push({ month: next.getMonth(), year: next.getFullYear(), eventos: [] })
   }
 
+  let coloredIndex = 0
+
 
   return (
     <div className={styles.container}>
@@ -141,29 +143,37 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
         <div className={styles.loading}>Carregando...</div>
       ) : (
         <div className={filterLoading ? styles.fade : ''}>
-          {months.map(({ month, year, eventos }) => (
-            <div
-              key={`${year}-${month}`}
-              className={styles.monthSection}
-            >
-            <h2 className={styles.monthTitle}>{formatMonthYear(month, year)}</h2>
-            {eventos.length === 0 ? (
-              <p className={styles.emptyMonth}>nada marcado</p>
-            ) : (
-              <div className={styles.grid}>
-                {eventos.map(p => (
-                  <EventCard
-                    key={p.id}
-                    event={p}
-                    onEditar={onEditar}
-                    onExcluir={handleExcluirClick}
-                    onDetalhes={onEditar}
-                  />
-                ))}
+          {months.map(({ month, year, eventos }) => {
+            let gray = false
+            if (eventos.length > 0) {
+              gray = coloredIndex % 2 === 1
+              coloredIndex++
+            }
+            return (
+              <div
+                key={`${year}-${month}`}
+                className={styles.monthSection}
+              >
+                <h2 className={styles.monthTitle}>{formatMonthYear(month, year)}</h2>
+                {eventos.length === 0 ? (
+                  <p className={styles.emptyMonth}>nada marcado</p>
+                ) : (
+                  <div className={styles.grid}>
+                    {eventos.map(p => (
+                      <EventCard
+                        key={p.id}
+                        event={p}
+                        onEditar={onEditar}
+                        onExcluir={handleExcluirClick}
+                        onDetalhes={onEditar}
+                        gray={gray}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
-            )}
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- alternate month card colors between white and grey
- show clock icon next to event time
- display scheduled date as `dia-mês-ano`

## Testing
- `npm run build` *(fails: Cannot find module due to network restrictions)*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_686c210915bc832f825fa5242eb835c1