### PR TITLE
Ajustes visuais em títulos e cartões

### DIFF
--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -47,6 +47,7 @@
 .agendado { background: #06b6d4; }
 .proximo { background: #22c55e; }
 .passado { background: #6b7280; }
+.status { background: #f59e0b; }
 
 .info {
   list-style: none;

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -35,7 +35,12 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes, gray
       <div className={styles.header}>
         <h3>{event.nome}</h3>
         <span className={`${styles.badge} ${badgeColor(event.tipo)}`}>{event.tipo}</span>
-        {event.agendado && <span className={`${styles.badge} ${styles.agendado}`}>Agendado</span>}
+        {event.status && (
+          <span className={`${styles.badge} ${styles.status}`}>{event.status}</span>
+        )}
+        {event.agendado && (
+          <span className={`${styles.badge} ${styles.agendado}`}>Agendado</span>
+        )}
         <span className={`${styles.badge} ${future ? styles.proximo : styles.passado}`}>{future ? 'Próximo' : 'Passado'}</span>
       </div>
       <ul className={styles.info}>
@@ -46,7 +51,6 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes, gray
           {event.horarioEvento}
         </li>
         <li><span className={styles.icon}>📍</span>{event.local}</li>
-        <li><span className={styles.icon}>🏷️</span>{event.tipo}</li>
       </ul>
       <div className={styles.financeiro}>
         <div>R$ {event.valorVenda}</div>

--- a/src/components/ListaPalestras.module.css
+++ b/src/components/ListaPalestras.module.css
@@ -85,9 +85,10 @@
 
 .monthTitle {
   text-transform: capitalize;
-  margin: 0 0 0.5rem 0;
-  color: #6b7280;
-  font-weight: 500;
+  margin: 0 0 0.75rem 0;
+  color: #1f2937;
+  font-weight: 600;
+  font-size: 1.25rem;
 }
 
 .emptyMonth {


### PR DESCRIPTION
## Summary
- destacar mais os títulos mensais
- mostrar status do evento como badge no card
- remover linha com emoji de etiqueta

## Testing
- `npm run lint` *(falhou: Cannot use import statement outside a module)*
- `npm run build` *(falhou: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686c268430f4832f8173fabf2705218f