### PR TITLE
Fix status labels and highlight months

### DIFF
--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -319,7 +319,7 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
           <option value="">Selecione</option>
           <option value="Cancelada">Cancelada</option>
           <option value="Agendada">Agendada</option>
-          <option value="Concluída">Confirmada</option>
+          <option value="Confirmada">Confirmada</option>
         </select>
       </div>
       <div className={styles.field}>

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -48,6 +48,9 @@
 .proximo { background: #22c55e; }
 .passado { background: #6b7280; }
 .status { background: #f59e0b; }
+.statusCancelada { background: #ef4444; }
+.statusAgendada { background: #f59e0b; }
+.statusConfirmada { background: #22c55e; }
 
 .info {
   list-style: none;

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -20,6 +20,19 @@ function badgeColor(tipo: string) {
   }
 }
 
+function statusClass(status: string) {
+  switch (status.toLowerCase()) {
+    case 'cancelada':
+      return styles.statusCancelada
+    case 'agendada':
+      return styles.statusAgendada
+    case 'confirmada':
+      return styles.statusConfirmada
+    default:
+      return styles.status
+  }
+}
+
 export default function EventCard({ event, onEditar, onExcluir, onDetalhes, gray }: EventCardProps) {
   const data = new Date(event.dataMarcada + 'T12:00:00')
   const future = data >= new Date()
@@ -36,7 +49,7 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes, gray
         <h3>{event.nome}</h3>
         <span className={`${styles.badge} ${badgeColor(event.tipo)}`}>{event.tipo}</span>
         {event.status && (
-          <span className={`${styles.badge} ${styles.status}`}>{event.status}</span>
+          <span className={`${styles.badge} ${statusClass(event.status)}`}>{event.status}</span>
         )}
         {event.agendado && (
           <span className={`${styles.badge} ${styles.agendado}`}>Agendado</span>

--- a/src/components/ListaPalestras.module.css
+++ b/src/components/ListaPalestras.module.css
@@ -91,6 +91,11 @@
   font-size: 1.25rem;
 }
 
+.monthName {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
 .emptyMonth {
   opacity: 0.5;
   font-size: 0.875rem;

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -86,10 +86,10 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
 
 
   function formatMonthYear(month: number, year: number) {
-    return new Date(year, month, 1).toLocaleDateString('pt-BR', {
-      month: 'long',
-      year: 'numeric'
-    })
+    const date = new Date(year, month, 1)
+    const monthName = date.toLocaleDateString('pt-BR', { month: 'long' })
+    const yearName = date.toLocaleDateString('pt-BR', { year: 'numeric' })
+    return { monthName, yearName }
   }
 
   const months: { month: number; year: number; eventos: Palestra[] }[] = []
@@ -144,6 +144,7 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
       ) : (
         <div className={filterLoading ? styles.fade : ''}>
           {months.map(({ month, year, eventos }) => {
+            const { monthName, yearName } = formatMonthYear(month, year)
             let gray = false
             if (eventos.length > 0) {
               gray = coloredIndex % 2 === 1
@@ -154,7 +155,9 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
                 key={`${year}-${month}`}
                 className={styles.monthSection}
               >
-                <h2 className={styles.monthTitle}>{formatMonthYear(month, year)}</h2>
+                <h2 className={styles.monthTitle}>
+                  <span className={styles.monthName}>{monthName}</span> {yearName}
+                </h2>
                 {eventos.length === 0 ? (
                   <p className={styles.emptyMonth}>nada marcado</p>
                 ) : (


### PR DESCRIPTION
## Summary
- fix status dropdown to use value `Confirmada`
- color status badges for Cancelada, Agendada and Confirmada
- make month name bigger in list header

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686c291ada8c832f856c727ba442b920