### PR TITLE
Fix status display and month formatting

### DIFF
--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -49,7 +49,7 @@
 .passado { background: #6b7280; }
 .status { background: #f59e0b; }
 .statusCancelada { background: #ef4444; }
-.statusAgendada { background: #f59e0b; }
+.statusAgendada { background: #facc15; }
 .statusConfirmada { background: #22c55e; }
 
 .info {

--- a/src/components/ListaPalestras.module.css
+++ b/src/components/ListaPalestras.module.css
@@ -94,6 +94,7 @@
 .monthName {
   font-size: 1.5rem;
   font-weight: 700;
+  text-transform: uppercase;
 }
 
 .emptyMonth {

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -23,10 +23,21 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
   const [monthFilter, setMonthFilter] = useState('')
   const [filterLoading, setFilterLoading] = useState(false)
 
+  function normalizeStatus(status: string) {
+    const s = status?.toLowerCase()
+    if (s === 'cancelada') return 'Cancelada'
+    if (s === 'agendada') return 'Agendada'
+    if (s === 'confirmada') return 'Confirmada'
+    return status
+  }
+
   useEffect(() => {
     const q = query(collection(db, 'palestras'), orderBy('dataMarcada', 'asc'))
     const unsubscribe = onSnapshot(q, (snapshot) => {
-      const data = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })) as Palestra[]
+      const data = snapshot.docs.map(doc => {
+        const d = doc.data() as Palestra
+        return { id: doc.id, ...d, status: normalizeStatus(d.status) }
+      }) as Palestra[]
       setPalestras(data)
       setLoading(false)
     })
@@ -87,7 +98,9 @@ export default function ListaPalestras({ onEditar }: ListaPalestrasProps) {
 
   function formatMonthYear(month: number, year: number) {
     const date = new Date(year, month, 1)
-    const monthName = date.toLocaleDateString('pt-BR', { month: 'long' })
+    const monthName = date
+      .toLocaleDateString('pt-BR', { month: 'long' })
+      .toUpperCase()
     const yearName = date.toLocaleDateString('pt-BR', { year: 'numeric' })
     return { monthName, yearName }
   }


### PR DESCRIPTION
## Summary
- normalize status data when reading from Firestore
- show month names in uppercase
- adjust status color for scheduled events

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm run build` *(fails: Cannot find module 'react' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_686c2b5789b4832f9709690601cca360