### PR TITLE
Improve hover of event cards

### DIFF
--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  overflow: hidden;
   transition: transform 0.5s ease, box-shadow 0.5s ease;
 }
 
@@ -81,28 +82,36 @@
   color: #22c55e;
 }
 
+
+.extra {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 1rem;
+  background: white;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+}
+
+.card:hover .extra {
+  transform: translateY(0);
+}
+
 .resumo {
-  display: none;
   font-size: 0.875rem;
   color: #374151;
   background: #f9fafb;
   padding: 0.5rem;
   border-radius: 8px;
-  margin-top: 0.25rem;
-}
-
-.card:hover .resumo {
-  display: block;
 }
 
 .actions {
-  display: none;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-.card:hover .actions {
   display: flex;
+  gap: 0.5rem;
 }
 
 .actions button {

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -69,13 +69,15 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes, gray
         <div>R$ {event.valorVenda}</div>
         <div className={styles.lucro}>Lucro: R$ {event.lucroFinal}</div>
       </div>
-      {event.resumo && (
-        <p className={styles.resumo}>{event.resumo}</p>
-      )}
-      <div className={styles.actions}>
-        <button className={styles.details} onClick={() => onDetalhes(event)}>👁️ Ver Detalhes</button>
-        <button className={styles.edit} onClick={() => onEditar(event)}>✏️ Editar</button>
-        <button className={styles.delete} onClick={() => onExcluir(event)}>🗑️ Excluir</button>
+      <div className={styles.extra}>
+        {event.resumo && (
+          <p className={styles.resumo}>{event.resumo}</p>
+        )}
+        <div className={styles.actions}>
+          <button className={styles.details} onClick={() => onDetalhes(event)}>👁️ Ver Detalhes</button>
+          <button className={styles.edit} onClick={() => onEditar(event)}>✏️ Editar</button>
+          <button className={styles.delete} onClick={() => onExcluir(event)}>🗑️ Excluir</button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- prevent jitter when hovering over event cards
- show resumo/actions in an overlay that slides up on hover

## Testing
- `npm run lint` *(fails: SyntaxError in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_686d091fce1c832fae7a759d0aa35fdb