### PR TITLE
Refactor edit flow into details view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,20 +10,19 @@ function App() {
   const [modalOpen, setModalOpen] = useState(false)
   const [modalMode, setModalMode] = useState<'editar' | 'detalhes'>('editar')
 
-  const handleEditarPalestra = (palestra: Palestra) => {
-    setPalestraSelecionada(palestra)
-    setModalMode('editar')
-    setModalOpen(true)
-  }
-
   const handleDetalhesPalestra = (palestra: Palestra) => {
     setPalestraSelecionada(palestra)
     setModalMode('detalhes')
     setModalOpen(true)
   }
 
+  const enableEditMode = () => {
+    setModalMode('editar')
+  }
+
   const handleNovo = () => {
     setPalestraSelecionada(null)
+    setModalMode('editar')
     setModalOpen(true)
   }
 
@@ -31,13 +30,14 @@ function App() {
     <div className={styles.app}>
       <Header onNovoEvento={handleNovo} />
       <main className={styles.main}>
-        <ListaPalestras onEditar={handleEditarPalestra} onDetalhes={handleDetalhesPalestra} />
+        <ListaPalestras onDetalhes={handleDetalhesPalestra} />
         <CadastroPalestra
           palestraSelecionada={palestraSelecionada}
           onPalestraSalva={() => setModalOpen(false)}
           modo={modalMode}
           isOpen={modalOpen}
           onClose={() => setModalOpen(false)}
+          onEditar={enableEditMode}
         />
       </main>
     </div>

--- a/src/components/CadastroPalestra.module.css
+++ b/src/components/CadastroPalestra.module.css
@@ -128,6 +128,7 @@
   max-width: 600px;
   overflow-y: auto;
   overflow-x: hidden;
+  position: relative;
 }
 
 .close {
@@ -139,6 +140,18 @@
   top: 8px;
   right: 8px;
   color: #dc3545;
+}
+
+.editButton {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: #007bff;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 .tabs {

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -14,9 +14,10 @@ interface CadastroPalestraProps {
   isOpen: boolean
   onClose: () => void
   modo?: 'editar' | 'detalhes'
+  onEditar?: () => void
 }
 
-export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva, isOpen, onClose, modo = 'editar' }: CadastroPalestraProps) {
+export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva, isOpen, onClose, modo = 'editar', onEditar }: CadastroPalestraProps) {
   const readOnly = modo === 'detalhes'
   const [form, setForm] = useState<Palestra>({
     tipo: 'palestra',
@@ -272,6 +273,9 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
     <div className={styles.modal}>
       <div className={styles.modalContent}>
         <button className={styles.close} onClick={onClose}>×</button>
+        {modo === 'detalhes' && onEditar && (
+          <button className={styles.editButton} onClick={onEditar}>Editar</button>
+        )}
         <form
           className={`${styles.form} ${palestraSelecionada ? styles.editing : ''}`}
           onSubmit={readOnly ? e => e.preventDefault() : handleSubmit}

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -127,10 +127,6 @@
   background: #60a5fa;
   color: white;
 }
-.edit {
-  background: #fb923c;
-  color: white;
-}
 .delete {
   background: #ef4444;
   color: white;

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -3,7 +3,6 @@ import styles from './EventCard.module.css'
 
 interface EventCardProps {
   event: Palestra
-  onEditar: (p: Palestra) => void
   onExcluir: (p: Palestra) => void
   onDetalhes: (p: Palestra) => void
   gray?: boolean
@@ -33,7 +32,7 @@ function statusClass(status: string) {
   }
 }
 
-export default function EventCard({ event, onEditar, onExcluir, onDetalhes, gray }: EventCardProps) {
+export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventCardProps) {
   const data = new Date(event.dataMarcada + 'T12:00:00')
   const future = data >= new Date()
   const formattedDate = data
@@ -75,7 +74,6 @@ export default function EventCard({ event, onEditar, onExcluir, onDetalhes, gray
         )}
         <div className={styles.actions}>
           <button className={styles.details} onClick={() => onDetalhes(event)}>👁️ Ver Detalhes</button>
-          <button className={styles.edit} onClick={() => onEditar(event)}>✏️ Editar</button>
           <button className={styles.delete} onClick={() => onExcluir(event)}>🗑️ Excluir</button>
         </div>
       </div>

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -9,11 +9,10 @@ import StatsCards from './StatsCards'
 import styles from './ListaPalestras.module.css'
 
 interface ListaPalestrasProps {
-  onEditar: (p: Palestra) => void
   onDetalhes: (p: Palestra) => void
 }
 
-export default function ListaPalestras({ onEditar, onDetalhes }: ListaPalestrasProps) {
+export default function ListaPalestras({ onDetalhes }: ListaPalestrasProps) {
   const [palestras, setPalestras] = useState<Palestra[]>([])
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
@@ -180,7 +179,6 @@ export default function ListaPalestras({ onEditar, onDetalhes }: ListaPalestrasP
                       <EventCard
                         key={p.id}
                         event={p}
-                        onEditar={onEditar}
                         onExcluir={handleExcluirClick}
                         onDetalhes={onDetalhes}
                         gray={gray}


### PR DESCRIPTION
## Summary
- Remove inline edit button from event cards
- Add top-level "Editar" button in details modal to enable editing
- Wire modal editing through App state

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689faae4ceec832f804e85790d136324