### PR TITLE
refactor: improve talk details modal header

### DIFF
--- a/src/components/CadastroPalestra.module.css
+++ b/src/components/CadastroPalestra.module.css
@@ -27,15 +27,6 @@
   border-left: 4px solid #007bff;
 }
 
-.form h2 {
-  grid-column: 1 / -1;
-  margin: 0 0 1rem 0;
-  color: #333;
-}
-
-.form.editing h2 {
-  color: #007bff;
-}
 
 .field {
   display: flex;
@@ -119,9 +110,7 @@
 }
 
 .modalContent {
-  background: white;
-  padding: 1rem;
-  padding-right: 2.5rem;
+  background: var(--surface, #ffffff);
   border-radius: 4px;
   max-height: 90vh;
   width: 90%;
@@ -129,48 +118,134 @@
   overflow-y: auto;
   overflow-x: hidden;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
-.close {
-  background: transparent;
-  border: none;
-  font-size: 3.5rem;
-  cursor: pointer;
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  color: #dc3545;
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--surface, #ffffff);
+}
+
+.topRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 56px;
+  padding: 12px 16px 0 16px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary, #1f2937);
+  flex: 1;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .editButton {
-  position: absolute;
-  top: 8px;
-  left: 8px;
-  background: #007bff;
-  color: white;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  color: var(--brand-600, #2563eb);
+  min-width: 40px;
+  height: 36px;
+  padding: 0 10px;
   cursor: pointer;
+}
+
+.editButton:hover {
+  color: var(--brand-700, #1d4ed8);
+}
+
+.editButton:focus-visible {
+  outline: 2px solid var(--brand-600, #2563eb);
+  outline-offset: 2px;
+}
+
+.editIcon {
+  font-size: 16px;
+}
+
+.closeButton {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  color: var(--text-secondary, #6b7280);
+  cursor: pointer;
+}
+
+.closeButton:hover {
+  color: var(--brand-600, #2563eb);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--brand-600, #2563eb);
+  outline-offset: 2px;
 }
 
 .tabs {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: 8px;
+  padding: 0 12px 4px;
+  border-bottom: 1px solid var(--border-subtle, #e5e7eb);
+  overflow-x: auto;
 }
 
-.tabs button {
-  flex: 1;
-  padding: 0.5rem;
+.tabButton {
+  position: relative;
+  background: transparent;
   border: none;
-  background: #e5e7eb;
+  padding: 8px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-secondary, #6b7280);
   cursor: pointer;
-  border-radius: 4px;
-  min-width: 0;
+  flex-shrink: 0;
 }
 
-.activeTab {
-  background: #fb923c;
-  color: white;
+.tabButton[aria-selected="true"] {
+  color: var(--text-primary, #1f2937);
+}
+
+.tabButton[aria-selected="true"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -4px;
+  height: 2px;
+  background: var(--brand-600, #2563eb);
+  border-radius: 0;
+}
+
+.tabButton:focus-visible {
+  outline: 2px solid var(--brand-600, #2563eb);
+  outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  .editLabel {
+    display: none;
+  }
+  .tabs {
+    overflow-x: auto;
+  }
 }

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -58,7 +58,42 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [tab, setTab] = useState<'basico' | 'financeiro' | 'viagem'>('basico')
+  const tabItems = [
+    { id: 'basico', label: 'Básico' },
+    { id: 'financeiro', label: 'Financeiro' },
+    { id: 'viagem', label: 'Viagem' }
+  ] as const
+  const [tab, setTab] = useState<(typeof tabItems)[number]['id']>('basico')
+
+  const handleTabKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    const { key } = e
+    const lastIndex = tabItems.length - 1
+    let newIndex = index
+
+    if (key === 'ArrowRight') {
+      newIndex = index === lastIndex ? 0 : index + 1
+    } else if (key === 'ArrowLeft') {
+      newIndex = index === 0 ? lastIndex : index - 1
+    } else if (key === 'Home') {
+      newIndex = 0
+    } else if (key === 'End') {
+      newIndex = lastIndex
+    } else if (key === 'Enter' || key === ' ') {
+      setTab(tabItems[index].id)
+      return
+    } else {
+      return
+    }
+
+    e.preventDefault()
+    const newTab = tabItems[newIndex].id
+    setTab(newTab)
+    const btn = document.getElementById(`tab-${newTab}`)
+    btn?.focus()
+  }
 
   useEffect(() => {
     if (palestraSelecionada) {
@@ -272,30 +307,60 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
   return (
     <div className={styles.modal}>
       <div className={styles.modalContent}>
-        <button className={styles.close} onClick={onClose}>×</button>
-        {modo === 'detalhes' && onEditar && (
-          <button className={styles.editButton} onClick={onEditar}>Editar</button>
-        )}
+        <div className={styles.header}>
+          <div className={styles.topRow}>
+            <h2 className={styles.title}>
+              {modo === 'detalhes'
+                ? 'Detalhes da Palestra'
+                : palestraSelecionada
+                ? 'Editar Palestra'
+                : 'Nova Palestra'}
+            </h2>
+            <div className={styles.actions}>
+              {modo === 'detalhes' && onEditar && (
+                <button
+                  type="button"
+                  className={styles.editButton}
+                  onClick={onEditar}
+                >
+                  <span aria-hidden="true" className={styles.editIcon}>✎</span>
+                  <span className={styles.editLabel}>Editar</span>
+                </button>
+              )}
+              <button
+                type="button"
+                className={styles.closeButton}
+                aria-label="Fechar"
+                onClick={onClose}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+          <nav className={styles.tabs} role="tablist">
+            {tabItems.map((t, i) => (
+              <button
+                key={t.id}
+                id={`tab-${t.id}`}
+                type="button"
+                role="tab"
+                aria-selected={tab === t.id}
+                tabIndex={tab === t.id ? 0 : -1}
+                onClick={() => setTab(t.id)}
+                onKeyDown={e => handleTabKeyDown(e, i)}
+                className={styles.tabButton}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
+        </div>
         <form
           className={`${styles.form} ${palestraSelecionada ? styles.editing : ''}`}
           onSubmit={readOnly ? e => e.preventDefault() : handleSubmit}
         >
-      <h2>
-        {modo === 'detalhes'
-          ? 'Detalhes da Palestra'
-          : palestraSelecionada
-          ? 'Editar Palestra'
-          : 'Nova Palestra'}
-      </h2>
-
-      <nav className={styles.tabs}>
-        <button type="button" className={tab === 'basico' ? styles.activeTab : ''} onClick={() => setTab('basico')}>Básico</button>
-        <button type="button" className={tab === 'financeiro' ? styles.activeTab : ''} onClick={() => setTab('financeiro')}>Financeiro</button>
-        <button type="button" className={tab === 'viagem' ? styles.activeTab : ''} onClick={() => setTab('viagem')}>Viagem</button>
-      </nav>
-
       {error && <div className={styles.error}>{error}</div>}
-      
+
       {/* Bloco Inicial Prioritário */}
       {tab === 'basico' && (
         <>


### PR DESCRIPTION
## Summary
- restructure talk details modal header into semantic zones with responsive actions and tabs
- implement accessible tab keyboard navigation and focus styling
- refresh styles using design tokens, ghost edit button, and subtle close icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a6286b8e80832f8505013c93edaf3a