### PR TITLE
Refactor event card to display key talk info

### DIFF
--- a/backend/types/Palestra.ts
+++ b/backend/types/Palestra.ts
@@ -35,4 +35,10 @@ export interface Palestra {
     valorFinalRecebido: number
     custoFinal: number
     agendado: boolean
+    /** Lista de tags associadas à palestra */
+    tags?: string[]
+    /** Nome do contratante da palestra */
+    contratante?: string
+    /** Cidade onde ocorrerá a palestra */
+    cidade?: string
 }

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -1,5 +1,4 @@
 .card {
-  position: relative;
   background: white;
   border-radius: 12px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
@@ -7,111 +6,69 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  overflow: hidden;
   transition: transform 0.5s ease, box-shadow 0.5s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
 }
 
 .gray {
   background: #d6d6d6;
 }
 
-.card:hover {
-  transition: transform 0.5s ease, box-shadow 0.5s ease;
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
-}
-
 .header {
   display: flex;
-  flex-wrap: wrap;
+  justify-content: space-between;
   align-items: center;
-  gap: 0.25rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .header h3 {
-  flex: 1 0 100%;
   margin: 0;
-  color: #000;
   font-size: 1.1rem;
+  color: #000;
 }
 
-.badge {
+.tags {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  background: #e5e7eb;
+  color: #374151;
   padding: 2px 6px;
   border-radius: 8px;
   font-size: 0.75rem;
-  color: white;
 }
-
-.palestra { background: #3b82f6; }
-.curso { background: #6366f1; }
-.outro { background: #8b5cf6; }
-.agendado { background: #06b6d4; }
-.proximo { background: #22c55e; }
-.passado { background: #6b7280; }
-.status { background: #f59e0b; }
-.statusCancelada { background: #ef4444; }
-.statusAgendada { background: #facc15; }
-.statusConfirmada { background: #22c55e; }
 
 .info {
   list-style: none;
   padding: 0;
   margin: 0;
   display: grid;
-  gap: 0.5rem;
+  gap: 0.25rem;
   font-size: 0.875rem;
 }
+
 .info li {
   display: flex;
   align-items: center;
   gap: 0.25rem;
 }
+
 .icon {
   color: #6b7280;
-}
-
-.financeiro {
-  background: #f3f4f6;
-  padding: 0.75rem;
-  border-radius: 8px;
-  display: flex;
-  justify-content: space-between;
-}
-
-.lucro {
-  color: #22c55e;
-}
-
-
-.extra {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  padding: 1rem;
-  background: white;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  transform: translateY(100%);
-  transition: transform 0.3s ease;
-}
-
-.card:hover .extra {
-  transform: translateY(0);
-}
-
-.resumo {
-  font-size: 0.875rem;
-  color: #374151;
-  background: #f9fafb;
-  padding: 0.5rem;
-  border-radius: 8px;
 }
 
 .actions {
   display: flex;
   gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .actions button {
@@ -127,7 +84,9 @@
   background: #60a5fa;
   color: white;
 }
+
 .delete {
   background: #ef4444;
   color: white;
 }
+

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -8,33 +8,9 @@ interface EventCardProps {
   gray?: boolean
 }
 
-function badgeColor(tipo: string) {
-  switch (tipo) {
-    case 'curso':
-      return styles.curso
-    case 'outro':
-      return styles.outro
-    default:
-      return styles.palestra
-  }
-}
-
-function statusClass(status: string) {
-  switch (status.toLowerCase()) {
-    case 'cancelada':
-      return styles.statusCancelada
-    case 'agendada':
-      return styles.statusAgendada
-    case 'confirmada':
-      return styles.statusConfirmada
-    default:
-      return styles.status
-  }
-}
-
 export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventCardProps) {
+  // Formata data da palestra
   const data = new Date(event.dataMarcada + 'T12:00:00')
-  const future = data >= new Date()
   const formattedDate = data
     .toLocaleDateString('pt-BR', {
       day: '2-digit',
@@ -42,41 +18,70 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
       year: 'numeric',
     })
     .replace(/\//g, '-')
+
+  const confirmada = event.status?.toLowerCase() === 'confirmada'
+
   return (
     <div className={`${styles.card} ${gray ? styles.gray : ''}`}>
       <div className={styles.header}>
         <h3>{event.nome}</h3>
-        <span className={`${styles.badge} ${badgeColor(event.tipo)}`}>{event.tipo}</span>
-        {event.status && (
-          <span className={`${styles.badge} ${statusClass(event.status)}`}>{event.status}</span>
+        {event.tags && (
+          <div className={styles.tags}>
+            {event.tags.map(tag => (
+              <span key={tag} className={styles.tag}>{tag}</span>
+            ))}
+          </div>
         )}
-        {event.agendado && (
-          <span className={`${styles.badge} ${styles.agendado}`}>Agendado</span>
-        )}
-        <span className={`${styles.badge} ${future ? styles.proximo : styles.passado}`}>{future ? 'Próximo' : 'Passado'}</span>
       </div>
+
       <ul className={styles.info}>
+        <li>
+          <span className={styles.icon}>🏙️</span>
+          {event.cidade ?? event.local}
+        </li>
+        {event.contratante && (
+          <li>
+            <span className={styles.icon}>👤</span>
+            {event.contratante}
+          </li>
+        )}
+        <li>
+          <span className={styles.icon}>🤖</span>
+          {event.humanoide ? 'Com tecnologia' : 'Sem tecnologia'}
+        </li>
+        <li>
+          <span className={styles.icon}>✅</span>
+          {confirmada ? 'Confirmada' : 'Não confirmada'}
+        </li>
         <li>
           <span className={styles.icon}>📅</span>
           {formattedDate}
           <span className={styles.icon}>🕒</span>
           {event.horarioEvento}
         </li>
-        <li><span className={styles.icon}>📍</span>{event.local}</li>
-      </ul>
-      <div className={styles.financeiro}>
-        <div>R$ {event.valorVenda}</div>
-        <div className={styles.lucro}>Lucro: R$ {event.lucroFinal}</div>
-      </div>
-      <div className={styles.extra}>
-        {event.resumo && (
-          <p className={styles.resumo}>{event.resumo}</p>
+        {event.infoIda && (
+          <li>
+            <span className={styles.icon}>✈️</span>
+            Ida: {event.infoIda}
+          </li>
         )}
-        <div className={styles.actions}>
-          <button className={styles.details} onClick={() => onDetalhes(event)}>👁️ Ver Detalhes</button>
-          <button className={styles.delete} onClick={() => onExcluir(event)}>🗑️ Excluir</button>
-        </div>
+        {event.infoRetorno && (
+          <li>
+            <span className={styles.icon}>✈️</span>
+            Retorno: {event.infoRetorno}
+          </li>
+        )}
+      </ul>
+
+      <div className={styles.actions}>
+        <button className={styles.details} onClick={() => onDetalhes(event)}>
+          👁️ Ver Detalhes
+        </button>
+        <button className={styles.delete} onClick={() => onExcluir(event)}>
+          🗑️ Excluir
+        </button>
       </div>
     </div>
   )
 }
+

--- a/src/types/Palestra.ts
+++ b/src/types/Palestra.ts
@@ -35,4 +35,10 @@ export interface Palestra {
     valorFinalRecebido: number
     custoFinal: number
     agendado: boolean
+    /** Lista de tags associadas à palestra */
+    tags?: string[]
+    /** Nome do contratante da palestra */
+    contratante?: string
+    /** Cidade onde ocorrerá a palestra */
+    cidade?: string
 }


### PR DESCRIPTION
## Summary
- refactor EventCard to show city, tags, contratante, confirmation, tecnologia, and flight info
- add optional metadata fields to Palestra type on frontend and backend
- style EventCard for new layout

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c051d70528832fb0604314d6a609f3