### PR TITLE
Show technology tag only when selected and restore hover observations

### DIFF
--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -7,11 +7,32 @@
   flex-direction: column;
   gap: 0.75rem;
   transition: transform 0.5s ease, box-shadow 0.5s ease;
+  position: relative;
 }
 
 .card:hover {
   transform: translateY(-2px) scale(1.02);
   box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+.observacoes {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 0.5rem;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  max-width: 200px;
+  text-align: center;
+  z-index: 10;
+}
+
+.card:hover .observacoes {
+  display: block;
 }
 
 .gray {

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -23,6 +23,9 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
 
   return (
     <div className={`${styles.card} ${gray ? styles.gray : ''}`}>
+      {event.observacoes && (
+        <div className={styles.observacoes}>{event.observacoes}</div>
+      )}
       <div className={styles.header}>
         <h3>{event.nome}</h3>
         {event.tags && (
@@ -45,10 +48,12 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
             {event.contratante}
           </li>
         )}
-        <li>
-          <span className={styles.icon}>🤖</span>
-          {event.humanoide ? 'Com tecnologia' : 'Sem tecnologia'}
-        </li>
+        {event.humanoide && (
+          <li>
+            <span className={styles.icon}>🤖</span>
+            Com tecnologia
+          </li>
+        )}
         <li>
           <span className={styles.icon}>✅</span>
           {confirmada ? 'Confirmada' : 'Não confirmada'}


### PR DESCRIPTION
## Summary
- Only render technology indicator when a technology is selected
- Show event observations in a hover tooltip above cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: SyntaxError in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c067b262ac832f86d952536728f5f1