### PR TITLE
feat: highlight status and show robot on event card

### DIFF
--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -86,6 +86,31 @@
   color: #6b7280;
 }
 
+.status {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: bold;
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+  width: fit-content;
+}
+
+.confirmada {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.agendada {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.cancelada {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
 .actions {
   display: flex;
   gap: 0.5rem;

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -19,13 +19,32 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
     })
     .replace(/\//g, '-')
 
-  const confirmada = event.status?.toLowerCase() === 'confirmada'
+  const statusLower = event.status?.toLowerCase()
+  let statusIcon = '🟢'
+  let statusClass = 'confirmada'
+  let statusText = 'Confirmada'
+
+  if (statusLower === 'cancelada') {
+    statusIcon = '🔴'
+    statusClass = 'cancelada'
+    statusText = 'Cancelada'
+  } else if (statusLower === 'agendada' || statusLower === 'nao confirmada' || statusLower === 'não confirmada') {
+    statusIcon = '🟡'
+    statusClass = 'agendada'
+    statusText = 'Agendada'
+  }
 
   return (
     <div className={`${styles.card} ${gray ? styles.gray : ''}`}>
       {event.observacoes && (
         <div className={styles.observacoes}>{event.observacoes}</div>
       )}
+
+      <div className={`${styles.status} ${styles[statusClass]}`}>
+        <span className={styles.icon}>{statusIcon}</span>
+        {statusText}
+      </div>
+
       <div className={styles.header}>
         <h3>{event.nome}</h3>
         {event.tags && (
@@ -54,10 +73,12 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
             Com tecnologia
           </li>
         )}
-        <li>
-          <span className={styles.icon}>✅</span>
-          {confirmada ? 'Confirmada' : 'Não confirmada'}
-        </li>
+        {event.robo && (
+          <li>
+            <span className={styles.icon}>🤖</span>
+            {event.observacoesRobo ? `Robô: ${event.observacoesRobo}` : 'Robô'}
+          </li>
+        )}
         <li>
           <span className={styles.icon}>📅</span>
           {formattedDate}

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -26,7 +26,7 @@ export default function ListaPalestras({ onDetalhes }: ListaPalestrasProps) {
   function normalizeStatus(status: string) {
     const s = status?.toLowerCase()
     if (s === 'cancelada') return 'Cancelada'
-    if (s === 'agendada') return 'Agendada'
+    if (s === 'agendada' || s === 'nao confirmada' || s === 'não confirmada') return 'Agendada'
     if (s === 'confirmada') return 'Confirmada'
     return status
   }


### PR DESCRIPTION
## Summary
- display a robot indicator on event cards when a robot is selected
- move status to the top of the card with colored icons for each state
- normalize legacy "nao confirmada" statuses to "Agendada"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm run build` *(fails: Cannot find module 'dotenv' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c06c293e78832fa99a7defb69031ee