### PR TITLE
feat: improve date formatting and UI

### DIFF
--- a/src/components/CadastroPalestra.module.css
+++ b/src/components/CadastroPalestra.module.css
@@ -48,6 +48,11 @@
   font-size: 1rem;
 }
 
+.readonlyInput {
+  background: #f3f4f6;
+  color: #6b7280;
+}
+
 .field textarea {
   min-height: 100px;
   resize: vertical;

--- a/src/components/CadastroPalestra.tsx
+++ b/src/components/CadastroPalestra.tsx
@@ -5,6 +5,7 @@ import { collection, updateDoc, doc } from 'firebase/firestore'
 import { Palestra } from '../types/Palestra'
 import styles from './CadastroPalestra.module.css'
 import {v4 as uuidv4} from "uuid";
+import { formatDate } from '../utils/formatDate'
 
 import { setDoc } from 'firebase/firestore'; // Adicione esta importação
 const API_URL = import.meta.env.VITE_BACKEND_URL || ""
@@ -386,14 +387,22 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       </div>
       <div className={styles.field}>
         <label>Data Marcada: <span className={styles.required}>*</span></label>
-        <input
-          type="date"
-          name="dataMarcada"
-          value={form.dataMarcada}
-          onChange={handleChange}
-          required
-          disabled={readOnly}
-        />
+        {readOnly ? (
+          <input
+            type="text"
+            value={formatDate(form.dataMarcada)}
+            readOnly
+            className={styles.readonlyInput}
+          />
+        ) : (
+          <input
+            type="date"
+            name="dataMarcada"
+            value={form.dataMarcada}
+            onChange={handleChange}
+            required
+          />
+        )}
       </div>
       <div className={styles.field}>
         <label>Status:</label>
@@ -482,11 +491,39 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
         <>
       <div className={styles.field}>
         <label>Informações de Ida:</label>
-        <input type="date" name="infoIda" value={form.infoIda} onChange={handleChange} disabled={readOnly} />
+        {readOnly ? (
+          <input
+            type="text"
+            value={formatDate(form.infoIda)}
+            readOnly
+            className={styles.readonlyInput}
+          />
+        ) : (
+          <input
+            type="date"
+            name="infoIda"
+            value={form.infoIda}
+            onChange={handleChange}
+          />
+        )}
       </div>
       <div className={styles.field}>
         <label>Informações de Retorno:</label>
-        <input type="date" name="infoRetorno" value={form.infoRetorno} onChange={handleChange} disabled={readOnly} />
+        {readOnly ? (
+          <input
+            type="text"
+            value={formatDate(form.infoRetorno)}
+            readOnly
+            className={styles.readonlyInput}
+          />
+        ) : (
+          <input
+            type="date"
+            name="infoRetorno"
+            value={form.infoRetorno}
+            onChange={handleChange}
+          />
+        )}
       </div>
       <div className={styles.field}>
         <label>Hospedagem Inclusa:</label>
@@ -593,7 +630,21 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       </div>
       <div className={styles.field}>
         <label>Data/Pagamento do Bônus:</label>
-        <input type="date" name="dataBonus" value={form.dataBonus} onChange={handleChange} disabled={readOnly} />
+        {readOnly ? (
+          <input
+            type="text"
+            value={formatDate(form.dataBonus)}
+            readOnly
+            className={styles.readonlyInput}
+          />
+        ) : (
+          <input
+            type="date"
+            name="dataBonus"
+            value={form.dataBonus}
+            onChange={handleChange}
+          />
+        )}
       </div>
       <div className={styles.field}>
         <label>Status do Bônus:</label>
@@ -603,7 +654,21 @@ export default function CadastroPalestra({ palestraSelecionada, onPalestraSalva,
       {/* Nota Fiscal */}
       <div className={styles.field}>
         <label>Data de Emissão da NF:</label>
-        <input type="date" name="dataNF" value={form.dataNF} onChange={handleChange} disabled={readOnly} />
+        {readOnly ? (
+          <input
+            type="text"
+            value={formatDate(form.dataNF)}
+            readOnly
+            className={styles.readonlyInput}
+          />
+        ) : (
+          <input
+            type="date"
+            name="dataNF"
+            value={form.dataNF}
+            onChange={handleChange}
+          />
+        )}
       </div>
       <div className={styles.field}>
         <label>Número da Nota Fiscal:</label>

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -82,6 +82,14 @@
   gap: 0.25rem;
 }
 
+.dateTime {
+  gap: 0.5rem;
+}
+
+.dateTime time {
+  font-weight: 500;
+}
+
 .icon {
   color: #6b7280;
 }

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,5 +1,6 @@
 import { Palestra } from '../types/Palestra'
 import styles from './EventCard.module.css'
+import { formatDate } from '../utils/formatDate'
 
 interface EventCardProps {
   event: Palestra
@@ -10,14 +11,7 @@ interface EventCardProps {
 
 export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventCardProps) {
   // Formata data da palestra
-  const data = new Date(event.dataMarcada + 'T12:00:00')
-  const formattedDate = data
-    .toLocaleDateString('pt-BR', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    })
-    .replace(/\//g, '-')
+  const formattedDate = formatDate(event.dataMarcada)
 
   const statusLower = event.status?.toLowerCase()
   let statusIcon = '🟢'
@@ -79,22 +73,22 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
             {event.observacoesRobo ? `Robô: ${event.observacoesRobo}` : 'Robô'}
           </li>
         )}
-        <li>
+        <li className={styles.dateTime}>
           <span className={styles.icon}>📅</span>
-          {formattedDate}
+          <time dateTime={event.dataMarcada}>{formattedDate}</time>
           <span className={styles.icon}>🕒</span>
-          {event.horarioEvento}
+          <time dateTime={event.horarioEvento}>{event.horarioEvento}</time>
         </li>
         {event.infoIda && (
           <li>
             <span className={styles.icon}>✈️</span>
-            Ida: {event.infoIda}
+            Ida: {formatDate(event.infoIda)}
           </li>
         )}
         {event.infoRetorno && (
           <li>
             <span className={styles.icon}>✈️</span>
-            Retorno: {event.infoRetorno}
+            Retorno: {formatDate(event.infoRetorno)}
           </li>
         )}
       </ul>

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,9 @@
+export function formatDate(isoDate: string): string {
+  if (!isoDate) return ''
+  const date = new Date(isoDate + 'T00:00:00')
+  return date.toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric'
+  })
+}


### PR DESCRIPTION
## Summary
- add formatDate helper to unify date presentation
- show dates in EventCard and CadastroPalestra using day/month/year
- style date displays for clearer UI

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm run build` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68c07c565588832f99af13c7d0b08638