### PR TITLE
Add list view and display mode selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ function App() {
   const [palestraSelecionada, setPalestraSelecionada] = useState<Palestra | null>(null)
   const [modalOpen, setModalOpen] = useState(false)
   const [modalMode, setModalMode] = useState<'editar' | 'detalhes'>('editar')
+  const [viewMode, setViewMode] = useState<'card' | 'list'>('card')
 
   const handleDetalhesPalestra = (palestra: Palestra) => {
     setPalestraSelecionada(palestra)
@@ -28,9 +29,13 @@ function App() {
 
   return (
     <div className={styles.app}>
-      <Header onNovoEvento={handleNovo} />
+      <Header
+        onNovoEvento={handleNovo}
+        viewMode={viewMode}
+        onChangeViewMode={setViewMode}
+      />
       <main className={styles.main}>
-        <ListaPalestras onDetalhes={handleDetalhesPalestra} />
+        <ListaPalestras onDetalhes={handleDetalhesPalestra} mode={viewMode} />
         <CadastroPalestra
           palestraSelecionada={palestraSelecionada}
           onPalestraSalva={() => setModalOpen(false)}

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -7,10 +7,54 @@
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-.header h1 {
+.titleArea {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.titleArea h1 {
   margin: 0;
   color: #000;
   font-size: 1.5rem;
+}
+
+.menuWrapper {
+  position: relative;
+}
+
+.menuButton {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+.menuDropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.menuDropdown button {
+  background: transparent;
+  border: none;
+  padding: 0.5rem 1rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.menuDropdown button:hover,
+.activeOption {
+  background: #f3f4f6;
 }
 
 .newButton {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,50 @@
+import { useState } from 'react'
 import styles from './Header.module.css'
 
 interface HeaderProps {
   onNovoEvento: () => void
+  viewMode: 'card' | 'list'
+  onChangeViewMode: (mode: 'card' | 'list') => void
 }
 
-export default function Header({ onNovoEvento }: HeaderProps) {
+export default function Header({ onNovoEvento, viewMode, onChangeViewMode }: HeaderProps) {
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  const handleSelect = (mode: 'card' | 'list') => {
+    onChangeViewMode(mode)
+    setMenuOpen(false)
+  }
+
   return (
     <header className={styles.header}>
-      <h1>DashTony</h1>
+      <div className={styles.titleArea}>
+        <h1>DashTony</h1>
+        <div className={styles.menuWrapper}>
+          <button
+            className={styles.menuButton}
+            onClick={() => setMenuOpen(o => !o)}
+            aria-label="Alterar modo de visualização"
+          >
+            ⋮
+          </button>
+          {menuOpen && (
+            <div className={styles.menuDropdown}>
+              <button
+                className={viewMode === 'card' ? styles.activeOption : ''}
+                onClick={() => handleSelect('card')}
+              >
+                Modo Card
+              </button>
+              <button
+                className={viewMode === 'list' ? styles.activeOption : ''}
+                onClick={() => handleSelect('list')}
+              >
+                Modo Lista
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
       <button className={styles.newButton} onClick={onNovoEvento}>
         <span className={styles.plus}>+</span> Novo Evento
       </button>

--- a/src/components/ListaPalestras.module.css
+++ b/src/components/ListaPalestras.module.css
@@ -111,3 +111,30 @@
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+}
+
+.grayRow {
+  background: #f9fafb;
+}
+
+.actionsCell button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  margin-right: 0.25rem;
+}
+
+.actionsCell button:last-child {
+  margin-right: 0;
+}

--- a/src/components/ListaPalestras.tsx
+++ b/src/components/ListaPalestras.tsx
@@ -7,12 +7,14 @@ import SearchBar from './SearchBar'
 import { Filter } from '../types/Filter'
 import StatsCards from './StatsCards'
 import styles from './ListaPalestras.module.css'
+import { formatDate } from '../utils/formatDate'
 
 interface ListaPalestrasProps {
   onDetalhes: (p: Palestra) => void
+  mode: 'card' | 'list'
 }
 
-export default function ListaPalestras({ onDetalhes }: ListaPalestrasProps) {
+export default function ListaPalestras({ onDetalhes, mode }: ListaPalestrasProps) {
   const [palestras, setPalestras] = useState<Palestra[]>([])
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
@@ -178,7 +180,7 @@ export default function ListaPalestras({ onDetalhes }: ListaPalestrasProps) {
                 </h2>
                 {eventos.length === 0 ? (
                   <p className={styles.emptyMonth}>nada marcado</p>
-                ) : (
+                ) : mode === 'card' ? (
                   <div className={styles.grid}>
                     {eventos.map(p => (
                       <EventCard
@@ -190,6 +192,36 @@ export default function ListaPalestras({ onDetalhes }: ListaPalestrasProps) {
                       />
                     ))}
                   </div>
+                ) : (
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>Nome</th>
+                        <th>Cidade/Local</th>
+                        <th>Contratante</th>
+                        <th>Data</th>
+                        <th>Hora</th>
+                        <th>Status</th>
+                        <th>Ações</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {eventos.map(p => (
+                        <tr key={p.id} className={gray ? styles.grayRow : ''}>
+                          <td>{p.nome}</td>
+                          <td>{p.cidade ?? p.local}</td>
+                          <td>{p.contratante}</td>
+                          <td>{formatDate(p.dataMarcada)}</td>
+                          <td>{p.horarioEvento}</td>
+                          <td>{normalizeStatus(p.status)}</td>
+                          <td className={styles.actionsCell}>
+                            <button onClick={() => onDetalhes(p)}>👁️</button>
+                            <button onClick={() => handleExcluirClick(p)}>🗑️</button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
                 )}
               </div>
             )


### PR DESCRIPTION
## Summary
- add dropdown menu in header to toggle between card and list modes
- implement list mode rendering items in table grouped by month
- style header dropdown and list layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run build` *(fails: Cannot find module 'dotenv' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c07f28f2f8832fb1c0797205067145