### PR TITLE
Add delayed tooltip for robot description

### DIFF
--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -15,8 +15,8 @@
   box-shadow: 0 4px 8px rgba(0,0,0,0.15);
 }
 
-.observacoes {
-  display: none;
+.observacoes,
+.roboPopup {
   position: absolute;
   top: 0;
   left: 50%;
@@ -31,8 +31,24 @@
   z-index: 10;
 }
 
+.observacoes {
+  display: none;
+}
+
 .card:hover .observacoes {
   display: block;
+}
+
+.roboTextWrapper {
+  position: relative;
+  flex: 1;
+}
+
+.roboText {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .gray {

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react'
 import { Palestra } from '../types/Palestra'
 import styles from './EventCard.module.css'
 import { formatDate } from '../utils/formatDate'
@@ -12,6 +13,23 @@ interface EventCardProps {
 export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventCardProps) {
   // Formata data da palestra
   const formattedDate = formatDate(event.dataMarcada)
+
+  const [showRoboPopup, setShowRoboPopup] = useState(false)
+  const roboHoverTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function handleRoboMouseEnter() {
+    roboHoverTimeout.current = setTimeout(() => {
+      setShowRoboPopup(true)
+    }, 2500)
+  }
+
+  function handleRoboMouseLeave() {
+    if (roboHoverTimeout.current) {
+      clearTimeout(roboHoverTimeout.current)
+      roboHoverTimeout.current = null
+    }
+    setShowRoboPopup(false)
+  }
 
   const statusLower = event.status?.toLowerCase()
   let statusIcon = '🟢'
@@ -70,7 +88,20 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
         {event.robo && (
           <li>
             <span className={styles.icon}>🤖</span>
-            {event.observacoesRobo ? `Robô: ${event.observacoesRobo}` : 'Robô'}
+            {event.observacoesRobo ? (
+              <div
+                className={styles.roboTextWrapper}
+                onMouseEnter={handleRoboMouseEnter}
+                onMouseLeave={handleRoboMouseLeave}
+              >
+                <span className={styles.roboText}>{`Robô: ${event.observacoesRobo}`}</span>
+                {showRoboPopup && (
+                  <div className={styles.roboPopup}>{`Robô: ${event.observacoesRobo}`}</div>
+                )}
+              </div>
+            ) : (
+              <span>Robô</span>
+            )}
           </li>
         )}
         <li className={styles.dateTime}>


### PR DESCRIPTION
## Summary
- limit robot description to one line with ellipsis on the card
- show full robot description in tooltip after 2.5s hover, styled like observations

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `NODE_OPTIONS=--experimental-vm-modules npx eslint .` *(fails: Cannot use import statement outside a module)*
- `npm run build` *(fails: Cannot find module 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68c084481350832f9b969d4a0d8fef37