### PR TITLE
fix: truncate robot observation

### DIFF
--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -42,6 +42,7 @@
 .roboTextWrapper {
   position: relative;
   flex: 1;
+  min-width: 0;
 }
 
 .roboText {

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -46,6 +46,10 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
     statusText = 'Agendada'
   }
 
+  const fullRoboText = event.observacoesRobo ? `Robô: ${event.observacoesRobo}` : ''
+  const displayRoboText =
+    fullRoboText.length > 25 ? `${fullRoboText.slice(0, 22)}...` : fullRoboText
+
   return (
     <div className={`${styles.card} ${gray ? styles.gray : ''}`}>
       {event.observacoes && (
@@ -94,9 +98,9 @@ export default function EventCard({ event, onExcluir, onDetalhes, gray }: EventC
                 onMouseEnter={handleRoboMouseEnter}
                 onMouseLeave={handleRoboMouseLeave}
               >
-                <span className={styles.roboText}>{`Robô: ${event.observacoesRobo}`}</span>
+                <span className={styles.roboText}>{displayRoboText}</span>
                 {showRoboPopup && (
-                  <div className={styles.roboPopup}>{`Robô: ${event.observacoesRobo}`}</div>
+                  <div className={styles.roboPopup}>{fullRoboText}</div>
                 )}
               </div>
             ) : (


### PR DESCRIPTION
## Summary
- ensure robot observation text doesn't overflow cards by limiting to 25 characters

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot use import statement outside a module)


------
https://chatgpt.com/codex/tasks/task_e_68c08a20bf78832fb5f6cb2f1306fb31